### PR TITLE
set Binding refs field type

### DIFF
--- a/src/imports.jl
+++ b/src/imports.jl
@@ -59,7 +59,7 @@ function _mark_import_arg(arg, par, state, u)
             if !hasmeta(arg)
                 arg.meta = Meta()
             end
-            arg.meta.binding = Binding(arg, par, _typeof(par), EXPR[], nothing, nothing)
+            arg.meta.binding = Binding(arg, par, _typeof(par), [], nothing, nothing)
         end
         if u && par isa SymbolServer.ModuleStore
             if state.scope.modules isa Dict

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -59,7 +59,7 @@ function _mark_import_arg(arg, par, state, u)
             if !hasmeta(arg)
                 arg.meta = Meta()
             end
-            arg.meta.binding = Binding(arg, par, _typeof(par), [], nothing, nothing)
+            arg.meta.binding = Binding(arg, par, _typeof(par), EXPR[], nothing, nothing)
         end
         if u && par isa SymbolServer.ModuleStore
             if state.scope.modules isa Dict

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -37,7 +37,7 @@ function handle_macro(x::EXPR, state)
             end
         elseif _points_to_Base_macro(x.args[1], "goto", state)
             if length(x.args) == 2 && typof(x.args[2]) === CSTParser.IDENTIFIER
-                setref!(x.args[2], Binding(noname, nothing, nothing, nothing, nothing, nothing))
+                setref!(x.args[2], Binding(noname, nothing, nothing, EXPR[], nothing, nothing))
             end
         elseif _points_to_Base_macro(x.args[1], "label", state)
             if length(x.args) == 2 && typof(x.args[2]) === CSTParser.IDENTIFIER

--- a/src/references.jl
+++ b/src/references.jl
@@ -75,7 +75,7 @@ function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes = Set{S
         mn = valof(x)
         x1 = x
         if (mn == "__source__" || mn == "__module__") && _in_macro_def(x)
-            setref!(x, Binding(noname, nothing, nothing, EXPR[], nothing, nothing))
+            setref!(x, Binding(noname, nothing, nothing, [], nothing, nothing))
             return true
         end
     elseif resolvable_macroname(x)
@@ -90,9 +90,9 @@ function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes = Set{S
         end
     elseif typof(x) === CSTParser.Kw
         if typof(x.args[1]) === IDENTIFIER
-            setref!(x.args[1], Binding(noname, nothing, nothing, EXPR[], nothing, nothing))
+            setref!(x.args[1], Binding(noname, nothing, nothing, [], nothing, nothing))
         elseif typof(x.args[1]) === BinaryOpCall && kindof(x.args[1].args[2]) === CSTParser.Tokens.DECLARATION && typof(x.args[1].args[1]) === IDENTIFIER
-            setref!(x.args[1].args[1], Binding(noname, nothing, nothing, EXPR[], nothing, nothing))
+            setref!(x.args[1].args[1], Binding(noname, nothing, nothing, [], nothing, nothing))
         end
         return true
     else
@@ -182,7 +182,7 @@ function resolve_getindex(x::EXPR, parent::SymbolServer.SymStore, state::State)
             fi = findfirst(f->valof(x) == f, parent.fields)
             val = resolve_typeref(parent.ts[fi], state)
             if val !== nothing
-                setref!(x, Binding(noname, nothing, val, EXPR[], nothing, nothing))
+                setref!(x, Binding(noname, nothing, val, [], nothing, nothing))
                 resolved = true
             end
         end

--- a/src/references.jl
+++ b/src/references.jl
@@ -75,7 +75,7 @@ function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes = Set{S
         mn = valof(x)
         x1 = x
         if (mn == "__source__" || mn == "__module__") && _in_macro_def(x)
-            setref!(x, Binding(noname, nothing, nothing, nothing, nothing, nothing))
+            setref!(x, Binding(noname, nothing, nothing, EXPR[], nothing, nothing))
             return true
         end
     elseif resolvable_macroname(x)
@@ -90,9 +90,9 @@ function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes = Set{S
         end
     elseif typof(x) === CSTParser.Kw
         if typof(x.args[1]) === IDENTIFIER
-            setref!(x.args[1], Binding(noname, nothing, nothing, nothing, nothing, nothing))
+            setref!(x.args[1], Binding(noname, nothing, nothing, EXPR[], nothing, nothing))
         elseif typof(x.args[1]) === BinaryOpCall && kindof(x.args[1].args[2]) === CSTParser.Tokens.DECLARATION && typof(x.args[1].args[1]) === IDENTIFIER
-            setref!(x.args[1].args[1], Binding(noname, nothing, nothing, nothing, nothing, nothing))
+            setref!(x.args[1].args[1], Binding(noname, nothing, nothing, EXPR[], nothing, nothing))
         end
         return true
     else
@@ -182,7 +182,7 @@ function resolve_getindex(x::EXPR, parent::SymbolServer.SymStore, state::State)
             fi = findfirst(f->valof(x) == f, parent.fields)
             val = resolve_typeref(parent.ts[fi], state)
             if val !== nothing
-                setref!(x, Binding(noname, nothing, val, [], nothing, nothing))
+                setref!(x, Binding(noname, nothing, val, EXPR[], nothing, nothing))
                 resolved = true
             end
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -34,7 +34,7 @@ function collect_bindings_refs(x::EXPR, bindings = [], refs = [])
 end
 
 function remove_ref(x::EXPR)
-    if hasref(x) && refof(x) isa Binding
+    if hasref(x) && refof(x) isa Binding && refof(x).refs isa Vector
         for ia in enumerate(refof(x).refs)
             if ia[2] == x
                 deleteat!(refof(x).refs, ia[1])


### PR DESCRIPTION
No need to leave this freely typed (and it's assumed to be a Vector in other packages). 