### PR TITLE
fix all typof module checks to include baremodules

### DIFF
--- a/src/imports.jl
+++ b/src/imports.jl
@@ -73,13 +73,13 @@ function _mark_import_arg(arg, par, state, u)
             else
                 state.scope.modules = Dict(valof(arg) => par.val)
             end
-        elseif u && par isa Binding && par.val isa EXPR && typof(par.val) === CSTParser.ModuleH
+        elseif u && par isa Binding && par.val isa EXPR && (typof(par.val) === CSTParser.ModuleH || typof(par.val) === CSTParser.BareModule)
             if state.scope.modules isa Dict
                 state.scope.modules[valof(arg)] = scopeof(par.val)
             else
                 state.scope.modules = Dict(valof(arg) => scopeof(par.val))
             end
-        elseif u && par isa Binding && par.val isa Binding && par.val.val isa EXPR && typof(par.val.val) === CSTParser.ModuleH
+        elseif u && par isa Binding && par.val isa Binding && par.val.val isa EXPR && (typof(par.val.val) === CSTParser.ModuleH || typof(par.val.val) === CSTParser.BareModule)
             if state.scope.modules isa Dict
                 state.scope.modules[valof(arg)] = scopeof(par.val.val)
             else
@@ -104,7 +104,7 @@ function _get_field(par, arg, state)
         if par.val isa Binding
             par = par.val
         end
-        if par.val isa EXPR && typof(par.val) === ModuleH
+        if par.val isa EXPR && (typof(par.val) === ModuleH || typof(par.val) === BareModule)
             if scopeof(par.val) isa Scope && haskey(scopeof(par.val).names, valof(arg))
                 return scopeof(par.val).names[valof(arg)]
             end

--- a/src/references.jl
+++ b/src/references.jl
@@ -60,7 +60,7 @@ end
 function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes = Set{String}())
     hasref(x) && return true
     resolved = false
-    if typof(scope.expr) === CSTParser.ModuleH || typof(scope.expr) === CSTParser.BareModule && CSTParser.length(scope.expr.args) > 1 && CSTParser.typof(scope.expr.args[2]) === IDENTIFIER
+    if (typof(scope.expr) === CSTParser.ModuleH || typof(scope.expr) === CSTParser.BareModule) && CSTParser.length(scope.expr.args) > 1 && CSTParser.typof(scope.expr.args[2]) === IDENTIFIER
         s_m_name = scope.expr.args[2].val isa String ? scope.expr.args[2].val : ""
         if s_m_name in visited_scopes
             return resolved
@@ -138,9 +138,9 @@ function resolve_getindex(x::EXPR, b::Binding, state::State)
         resolved = resolve_getindex(x, b.type.val, state)
     elseif b.val isa SymbolServer.ModuleStore
         resolved = resolve_getindex(x, b.val, state)
-    elseif b.val isa EXPR && typof(b.val) === ModuleH
+    elseif b.val isa EXPR && (typof(b.val) === ModuleH || typof(b.val) === BareModule)
         resolved = resolve_getindex(x, b.val, state)
-    elseif b.val isa Binding && b.val.val isa EXPR && typof(b.val.val) === ModuleH
+    elseif b.val isa Binding && b.val.val isa EXPR && (typof(b.val.val) === ModuleH || typof(b.val.val) === BareModule)
         resolved = resolve_getindex(x, b.val.val, state)
     end
     return resolved


### PR DESCRIPTION
Previous logic failed (in some places) to include baremodules when checking whether an EXPR defined a module