### PR TITLE
mark documented symbols

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -54,6 +54,9 @@ function handle_macro(x::EXPR, state)
                 end
             end
         end
+    elseif typof(x.args[1]) == CSTParser.GlobalRefDoc && length(x.args) == 3 && CSTParser.isliteral(x.args[2]) && kindof(x.args[2]) === CSTParser.Tokens.TRIPLE_STRING && isidentifier(x.args[3])
+        mark_binding!(x.args[3])
+        setref!(x.args[3], bindingof(x.args[3]))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -420,3 +420,17 @@ end
         @test !StaticLint.haserror(cst[3][4])
     end
 end
+
+@testset "docs for undescribed variables" begin
+let cst = parse_and_pass("""
+    \"\"\"
+        somefunc() = true
+    \"\"\"
+    somefunc
+    somefunc() = true
+    """)
+    @test StaticLint.hasref(cst[1][3])
+    @test StaticLint.hasbinding(cst[1][3])
+    @test refof(cst[1][3]) == bindingof(cst[1][3])
+end
+end


### PR DESCRIPTION
e.g. where documentation is attached to a symbol in advance of a meaningful variable declaration
```julia
""" 
    somefunc(a,b)
Some description
"""
somefunc
```