### PR TITLE
Miscfixes

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -150,7 +150,7 @@ function followinclude(x, state::State)
             state(getcst(state.file))
             state.file = oldfile
             pop!(state.included_files)
-        else
+        elseif !is_in_fexpr(x, CSTParser.defines_function)
             seterror!(x, MissingFile)
         end
     end

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -134,6 +134,16 @@ function followinclude(x, state::State)
         elseif canloadfile(state.server, joinpath(dirname(getpath(state.file)), path))
             path = joinpath(dirname(getpath(state.file)), path)
             loadfile(state.server, path)
+        elseif !isempty((basepath = _is_in_basedir(getpath(state.file)); basepath))
+            # Special handling for include method used within Base
+            path = joinpath(basepath, path)
+            if hasfile(state.server, path)
+                # skip
+            elseif canloadfile(state.server, path)
+                loadfile(state.server, path)
+            else
+                path = ""
+            end
         else
             path = ""
         end

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -237,7 +237,7 @@ function _in_func_def(x::EXPR)
     while true
         if typof(ex) === WhereOpCall || (typof(ex) === BinaryOpCall && kindof(ex.args[2]) === CSTParser.Tokens.DECLARATION)
             ex = ex.args[1]
-        elseif typof(ex) === Call || (typof(ex) === BinaryOpCall && !(kindof(ex.args[2]) === CSTParser.Tokens.DOT))
+        elseif typof(ex) === Call || (typof(ex) === BinaryOpCall && !(kindof(ex.args[2]) === CSTParser.Tokens.DOT)) || typof(ex) == CSTParser.UnaryOpCall #&& kindof(ex.args[1]) == CSTParser.Tokens.MINUS
             break
         else
             return false

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -266,3 +266,18 @@ function get_parent_fexpr(x::EXPR, f)
         return get_parent_fexpr(parentof(x), f)
     end
 end
+
+hasreadperm(p::String) = (uperm(p) & 0x04) == 0x04
+
+# check whether a path is in (including subfolders) the julia base dir. Returns "" if not, and the path to the base dir if so.
+function _is_in_basedir(path::AbstractString)
+    i = findfirst(r".*base", path)
+    i == nothing && return ""
+    path1 = path[i]
+    !hasreadperm(path1) && return ""
+    !isdir(path1) && return ""
+    files = readdir(path1)
+    if all(f -> f in files, ["Base.jl", "coreio.jl", "essentials.jl", "exports.jl"])
+        return path1
+    end
+end


### PR DESCRIPTION
- removes unhelpful hints on untraceable includes
- handles special include method in Base
- fixes a special case of ignoring scopes created by `where` statements 
- some fixes to check_call