### PR TITLE
Don't run resolve_ref when not needed

### DIFF
--- a/src/references.jl
+++ b/src/references.jl
@@ -113,7 +113,7 @@ function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes = [])
         end
         return true
     else
-        return false
+        return true
     end
     
     if haskey(scope.names, mn)


### PR DESCRIPTION
~30% speedup on a scopepass of `/base`. 