### PR TITLE
Allow `using` statements to access packages loaded within workspace

### DIFF
--- a/src/imports.jl
+++ b/src/imports.jl
@@ -90,7 +90,7 @@ function has_workspace_package(server, name)
     haskey(scopeof(getcst(server.workspacepackages[name])).names, name) &&
     scopeof(getcst(server.workspacepackages[name])).names[name] isa Binding &&
     scopeof(getcst(server.workspacepackages[name])).names[name].val isa EXPR &&
-    (typeof(scopeof(getcst(server.workspacepackages[name])).names[name].val) in (ModuleH, BareModule))
+    (typeof(scopeof(getcst(server.workspacepackages[name])).names[name].val) in (Module, BareModule))
 end
 
 function add_to_imported_modules(scope::Scope, name::Symbol, val)

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -88,10 +88,10 @@ function has_workspace_package(server, name)
     haskey(server.workspacepackages, name) &&
     hasscope(getcst(server.workspacepackages[name])) &&
     haskey(scopeof(getcst(server.workspacepackages[name])).names, name) &&
-    scopeof(getcst(server.workspacepackages[name])).names[name] isa Binding && 
-    scopeof(getcst(server.workspacepackages[name])).names[name].val isa EXPR && 
-    (typof(scopeof(getcst(server.workspacepackages[name])).names[name].val) in (ModuleH,BareModule))
-end 
+    scopeof(getcst(server.workspacepackages[name])).names[name] isa Binding &&
+    scopeof(getcst(server.workspacepackages[name])).names[name].val isa EXPR &&
+    (typeof(scopeof(getcst(server.workspacepackages[name])).names[name].val) in (ModuleH, BareModule))
+end
 
 function add_to_imported_modules(scope::Scope, name::Symbol, val)
     if scope.modules isa Dict

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -106,9 +106,9 @@ end
 function _get_field(par, arg, state)
     arg_str_rep = CSTParser.str_value(arg)
     if par isa SymbolServer.EnvStore # package store
-        if has_workspace_package(state.server, CSTParser.str_value(arg))
-            return scopeof(getcst(state.server.workspacepackages[CSTParser.str_value(arg)])).names[CSTParser.str_value(arg)]
-        elseif haskey(par, CSTParser.str_value(arg))
+        if has_workspace_package(state.server, arg_str_rep)
+            return scopeof(getcst(state.server.workspacepackages[arg_str_rep])).names[arg_str_rep]
+        elseif haskey(par, Symbol(arg_str_rep))
             return par[Symbol(arg_str_rep)]
         end
     elseif par isa Scope

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -96,11 +96,19 @@ function _mark_import_arg(arg, par, state, u)
     end
 end
 
+function has_workspace_package(server, name)
+    haskey(server.workspacepackages, name) &&
+    hasscope(getcst(server.workspacepackages[name])) &&
+    haskey(scopeof(getcst(server.workspacepackages[name])).names, name) &&
+    scopeof(getcst(server.workspacepackages[name])).names[name] isa Binding && 
+    scopeof(getcst(server.workspacepackages[name])).names[name].val isa EXPR && 
+    (typof(scopeof(getcst(server.workspacepackages[name])).names[name].val) in (ModuleH,BareModule))
+end 
 
 function _get_field(par, arg, state)
     if par isa Dict{String,SymbolServer.ModuleStore} # package store
-        if haskey(state.server.workspacepackages, CSTParser.str_value(arg))
-            return state.server.workspacepackages[CSTParser.str_value(arg)]
+        if has_workspace_package(state.server, CSTParser.str_value(arg))
+            return scopeof(getcst(state.server.workspacepackages[CSTParser.str_value(arg)])).names[CSTParser.str_value(arg)]
         elseif haskey(par, CSTParser.str_value(arg))
             return par[CSTParser.str_value(arg)]
         end

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -93,7 +93,9 @@ end
 
 function _get_field(par, arg, state)
     if par isa Dict{String,SymbolServer.ModuleStore} # package store
-        if haskey(par, CSTParser.str_value(arg))
+        if haskey(state.server.workspacepackages, CSTParser.str_value(arg))
+            return state.server.workspacepackages[CSTParser.str_value(arg)]
+        elseif haskey(par, CSTParser.str_value(arg))
             return par[CSTParser.str_value(arg)]
         end
     elseif par isa Scope

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -90,7 +90,7 @@ function has_workspace_package(server, name)
     haskey(scopeof(getcst(server.workspacepackages[name])).names, name) &&
     scopeof(getcst(server.workspacepackages[name])).names[name] isa Binding &&
     scopeof(getcst(server.workspacepackages[name])).names[name].val isa EXPR &&
-    (typeof(scopeof(getcst(server.workspacepackages[name])).names[name].val) in (Module, BareModule))
+    CSTParser.defines_module(scopeof(getcst(server.workspacepackages[name])).names[name].val)
 end
 
 function add_to_imported_modules(scope::Scope, name::Symbol, val)

--- a/src/references.jl
+++ b/src/references.jl
@@ -42,16 +42,8 @@ end
  
 function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes)::Bool
     hasref(x) && return true
-
     resolved = false
-    if (typof(scope.expr) === CSTParser.ModuleH || typof(scope.expr) === CSTParser.BareModule) && CSTParser.length(scope.expr) > 1 && CSTParser.typof(scope.expr[2]) === IDENTIFIER
-        s_m_name = scope.expr[2].val isa String ? scope.expr[2].val : ""
-        if s_m_name in visited_scopes
-            return resolved
-        else
-            push!(visited_scopes, s_m_name)
-        end
-    end
+    module_safety_trip(scope, visited_scopes) && return false
     
     if is_getfield(x)
         return resolve_getfield(x, scope, state)
@@ -94,7 +86,7 @@ function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes)::Bool
         resolved = true
     elseif scope.modules isa Dict && length(scope.modules) > 0
         for m in scope.modules
-            resolved = resolve_ref(x, m[2], state, visited_scopes)
+            resolved = resolve_ref_from_module(x, m[2], state, visited_scopes)
             resolved && return true
         end
     end
@@ -105,7 +97,7 @@ function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes)::Bool
 end
 
 # Searches a module store for a binding/variable that matches the reference `x1`.
-function resolve_ref(x1::EXPR, m::SymbolServer.ModuleStore, state::State, visited_scopes)::Bool
+function resolve_ref_from_module(x1::EXPR, m::SymbolServer.ModuleStore, state::State, visited_scopes)::Bool
     hasref(x1) && return true
     if isidentifier(x1)
         x = x1
@@ -140,6 +132,57 @@ function resolve_ref(x1::EXPR, m::SymbolServer.ModuleStore, state::State, visite
         if isexportedby(mn, m)
             setref!(mac[1], m[mn])
             return true
+        end
+    end
+    return false
+end
+
+function resolve_ref_from_module(x::EXPR, scope::Scope, state::State, visited_scopes)::Bool
+    hasref(x) && return true
+    resolved = false
+    module_safety_trip(scope, visited_scopes) && return false
+
+    if isidentifier(x)
+        if typof(x) === IDENTIFIER
+            mn = valof(x)
+            x1 = x
+        else
+            # NONSTDIDENTIFIER, e.g. var"name"
+            mn = valof(x[2])
+            x1 = x
+        end
+    elseif resolvable_macroname(x)
+        x1 = x[2]
+        mn = string("@", valof(x1))
+    elseif typof(x) === x_Str
+        if typof(x[1]) === IDENTIFIER
+            x1 = x[1]
+            mn = string("@", valof(x1), "_str")
+        else
+            return false
+        end
+    else
+        return true # TODO: Should be false?
+    end
+
+    if scope_exports(scope, mn)
+        setref!(x1, scope.names[mn])
+        resolved = true
+    end
+    return resolved
+end
+
+"""
+    scope_exports(scope::Scope, name::String)
+
+Does the scope export a variable called `name`?
+"""
+function scope_exports(scope::Scope, name::String)
+    if scopehasbinding(scope, name) && (b = scope.names[name]) isa Binding
+        for ref in b.refs
+            if ref isa EXPR && parentof(ref) isa EXPR && typof(parentof(ref)) === CSTParser.Export
+                return true
+            end
         end
     end
     return false
@@ -256,4 +299,22 @@ function _in_macro_def(x::EXPR)
     else
         return false
     end
+end
+
+"""
+    module_safety_trip(scope::Scope,  visited_scopes)
+
+Checks whether the scope is a module and we've visited it before, 
+otherwise adds the module to the list.
+"""
+function module_safety_trip(scope::Scope,  visited_scopes)
+    if CSTParser.defines_module(scope.expr) && CSTParser.length(scope.expr) > 1 && CSTParser.typof(scope.expr[2]) === IDENTIFIER
+        s_m_name = scope.expr[2].val isa String ? scope.expr[2].val : ""
+        if s_m_name in visited_scopes
+            return true
+        else
+            push!(visited_scopes, s_m_name)
+        end
+    end
+    return false
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -13,7 +13,7 @@ mutable struct FileServer <: AbstractServer
     files::Dict{String,File}
     roots::Set{File}
     symbolserver::Dict{String,SymbolServer.ModuleStore}
-    workspacepackages::Dict{String,Binding}
+    workspacepackages::Dict{String,File} # list of files that may represent within-workspace packages
 end
 
 # Interface spec.

--- a/src/server.jl
+++ b/src/server.jl
@@ -16,7 +16,7 @@ mutable struct FileServer <: AbstractServer
     symbol_extends::Dict{SymbolServer.VarRef, Vector{SymbolServer.VarRef}}
     workspacepackages::Dict{String,File} # list of files that may represent within-workspace packages
 end
-FileServer() = FileServer(Dict{String,File}(), Set{File}(), deepcopy(SymbolServer.stdlibs), SymbolServer.collect_extended_methods(SymbolServer.stdlibs))
+FileServer() = FileServer(Dict{String,File}(), Set{File}(), deepcopy(SymbolServer.stdlibs), SymbolServer.collect_extended_methods(SymbolServer.stdlibs), Dict{String,File}())
 
 # Interface spec.
 # AbstractServer :-> (has/canload/load/set/get)file, getsymbolserver, getsymbolextends

--- a/src/server.jl
+++ b/src/server.jl
@@ -13,6 +13,7 @@ mutable struct FileServer <: AbstractServer
     files::Dict{String,File}
     roots::Set{File}
     symbolserver::Dict{String,SymbolServer.ModuleStore}
+    workspacepackages::Dict{String,Binding}
 end
 
 # Interface spec.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1703,7 +1703,7 @@ end
     StaticLint.setroot(f2, f2)
     StaticLint.setfile(server, f2.path, f2)
     StaticLint.semantic_pass(f2)
-    @test StaticLint.hasref(StaticLint.getcst(f2)[1][2])
+    @test StaticLint.hasref(StaticLint.getcst(f2)[1][2][1])
     @test StaticLint.hasref(StaticLint.getcst(f2)[2])
     @test StaticLint.hasref(StaticLint.getcst(f2)[3][3][1])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1692,7 +1692,7 @@ end
     f1 = StaticLint.File("workspacemod.jl", s1, CSTParser.parse(s1, true), nothing, server)
     StaticLint.setroot(f1, f1)
     StaticLint.setfile(server, f1.path, f1)
-    StaticLint.scopepass(f1)
+    StaticLint.semantic_pass(f1)
     server.workspacepackages["WorkspaceMod"] = f1
     s2 = """
     using WorkspaceMod
@@ -1702,7 +1702,7 @@ end
     f2 = StaticLint.File("someotherfile.jl", s2, CSTParser.parse(s2, true), nothing, server)
     StaticLint.setroot(f2, f2)
     StaticLint.setfile(server, f2.path, f2)
-    StaticLint.scopepass(f2)
+    StaticLint.semantic_pass(f2)
     @test StaticLint.hasref(StaticLint.getcst(f2)[1][2])
     @test StaticLint.hasref(StaticLint.getcst(f2)[2])
     @test StaticLint.hasref(StaticLint.getcst(f2)[3][3][1])


### PR DESCRIPTION
I _think_ this is all that's needed on this side so that `using` statements will point to the 'live' code of packages that is being edited. Alongside the symbolserver store of packages I've added a new `workspacepackages` field which will be checked prior to the symbolserver list. It will be up to the user (e.g. the LanguageServerInstance) to ensure that this list is properly managed, I'll open a PR on the other side to discuss how this is managed.

Todo:

- [x] Add accessor function 


Example code:
```julia
using StaticLint, SymbolServer, CSTParser
using StaticLint: File, FileServer, loadfile, scopepass

server = FileServer(Dict(), Set(), deepcopy(SymbolServer.stdlibs), Dict{String,CSTParser.EXPR}());
f = loadfile(server, String(first(methods(CSTParser.eval)).file))
scopepass(f)
server.workspacepackages["CSTParser"] = f.cst.meta.scope.names["CSTParser"] #Load the local/live version of CSTParser

s = """
using CSTParser
ParseState
"""
f = File("none", s, CSTParser.parse(s, true), nothing, server)
f.root = f
scopepass(f)
f.cst
# FileH  27(26) new scope
#  Using  16(15)
#   USING  6(5)
#   CSTParser  10(9) Binding(CSTParser(1 refs)) * 
#  ParseState  11(10)  * 
```