### PR TITLE
Check that file is loaded into server before using it

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -147,7 +147,7 @@ function followinclude(x, state::State)
         else
             path = ""
         end
-        if !isempty(path)
+        if hasfile(state.server, path)
             if path in state.included_files
                 seterror!(x, IncludeLoop)
                 return


### PR DESCRIPTION
Fixes #116. Maybe :) I'm not really very familiar with this part of the code.

The main idea here is that `loadfile` can silently fail, so if we take one of the if clauses above that calls `loadfile`, but then that doesn't work (say the file has been deleted between the call to `canloadfile` and the call to `loadfile`) then we currently crash because there is a call to `getfile` later on that assumes that the file is actually loaded into the server.