### PR TITLE
Add warning of redfinition of constants through type definition

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -421,8 +421,9 @@ mutable struct LintOptions
     typeparam::Bool
     modname::Bool
     pirates::Bool
+    constredecl::Bool
 end
-LintOptions() = LintOptions(true, true, true, true, true, false, true, true, true)
+LintOptions() = LintOptions(true, true, true, true, true, false, true, true, true, true)
 
 function check_all(x::EXPR, opts::LintOptions, server)
     # Do checks
@@ -436,8 +437,8 @@ function check_all(x::EXPR, opts::LintOptions, server)
     opts.typeparam && check_typeparams(x)
     opts.modname && check_modulename(x)
     opts.pirates && check_for_pirates(x)
-    check_const_decl(x)
-    check_const_redef(x)
+    opts.constredecl && check_const_decl(x)
+    opts.constredecl && check_const_redef(x)
     for i in 1:length(x)
         check_all(x[i], opts, server)
     end

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -421,9 +421,8 @@ mutable struct LintOptions
     typeparam::Bool
     modname::Bool
     pirates::Bool
-    constredecl::Bool
 end
-LintOptions() = LintOptions(true, true, true, true, true, false, true, true, true, true)
+LintOptions() = LintOptions(true, true, true, true, true, false, true, true, true)
 
 function check_all(x::EXPR, opts::LintOptions, server)
     # Do checks
@@ -437,8 +436,8 @@ function check_all(x::EXPR, opts::LintOptions, server)
     opts.typeparam && check_typeparams(x)
     opts.modname && check_modulename(x)
     opts.pirates && check_for_pirates(x)
-    opts.constredecl && check_const_decl(x)
-    opts.constredecl && check_const_redef(x)
+    check_const_decl(x)
+    check_const_redef(x)
     for i in 1:length(x)
         check_all(x[i], opts, server)
     end
@@ -559,7 +558,7 @@ function check_const_decl(x::EXPR)
 end
 
 function check_const_redef(x::EXPR)
-    if hasbinding(x) && bindingof(x).prev isa Binding && bindingof(x).prev.type === CoreTypes.DataType && bindingof(x).type !== CoreTypes.Function
+    if hasbinding(x) && bindingof(x) isa Binding && bindingof(x).prev isa Binding && bindingof(x).prev.type === CoreTypes.DataType && bindingof(x).type !== CoreTypes.Function
         seterror!(x, InvalidRedefofConst)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -735,4 +735,28 @@ end
     end
 end
 
+@testset "check redefinition of const" begin
+    let cst = parse_and_pass("""
+        T = 1
+        struct T end
+        """)
+        StaticLint.check_const_decl(cst[2])
+        @test cst[2].meta.error == StaticLint.CannotDeclareConst
+    end
+    let cst = parse_and_pass("""
+        struct T end
+        T = 1
+        """)
+        StaticLint.check_const_redef(cst[2][1])
+        @test cst[2][1].meta.error == StaticLint.InvalidRedefofConst
+    end
+    let cst = parse_and_pass("""
+        struct T end
+        T() = 1
+        """)
+        StaticLint.check_const_redef(cst[2])
+        @test cst[2].meta.error == nothing
+    end
+end
+
 end


### PR DESCRIPTION
Adds warnings for the following situations:
```julia
struct T end
T = 1
```
and
```julia
T = 1
struct T end
```

I've not added a configuration option for this as its more of a 'this will not run' lint 