### PR TITLE
Add some inference based on use of getfield.

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -69,6 +69,12 @@ function (state::State)(x::EXPR)
 
     # return to previous states
     state.scope != s0 && (state.scope = s0)
+    
+    if hasscope(x) && scopeof(x) !== state.scope && typof(x) !== CSTParser.ModuleH && typof(x) !== CSTParser.BareModule && typof(x) !== CSTParser.FileH && !CSTParser.defines_datatype(x)
+        for (n,b) in scopeof(x).names
+            infer_type_by_getfield_calls(b, state.server)
+        end
+    end
     state.delayed = delayed
     return state.scope
 end

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -72,7 +72,7 @@ function (state::State)(x::EXPR)
     
     if state.file == state.targetfile && hasscope(x) && scopeof(x) !== state.scope && typof(x) !== CSTParser.ModuleH && typof(x) !== CSTParser.BareModule && typof(x) !== CSTParser.FileH && !CSTParser.defines_datatype(x)
         for (n,b) in scopeof(x).names
-            infer_type_by_getfield_calls(b, state.server)
+            infer_type_by_use(b, state.server)
         end
     end
     state.delayed = delayed

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -70,7 +70,7 @@ function (state::State)(x::EXPR)
     # return to previous states
     state.scope != s0 && (state.scope = s0)
     
-    if hasscope(x) && scopeof(x) !== state.scope && typof(x) !== CSTParser.ModuleH && typof(x) !== CSTParser.BareModule && typof(x) !== CSTParser.FileH && !CSTParser.defines_datatype(x)
+    if state.file == state.targetfile && hasscope(x) && scopeof(x) !== state.scope && typof(x) !== CSTParser.ModuleH && typof(x) !== CSTParser.BareModule && typof(x) !== CSTParser.FileH && !CSTParser.defines_datatype(x)
         for (n,b) in scopeof(x).names
             infer_type_by_getfield_calls(b, state.server)
         end

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -76,7 +76,7 @@ function (state::Toplevel)(x::EXPR)
             infer_type_by_use(b, state.server)
         end
     end
-    state.delayed = delayed
+
     return state.scope
 end
 
@@ -95,6 +95,7 @@ function (state::Delayed)(x::EXPR)
 
     traverse(x, state)
     
+    # needs to call to add infer_type_by_use
     state.scope != s0 && (state.scope = s0)
     return state.scope
 end

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -50,7 +50,15 @@ function resolve_import(x, state::State)
     end
 end
 
-function _mark_import_arg(arg, par, state, u)
+function add_to_imported_modules(scope::Scope, name::Symbol, val)
+    if scope.modules isa Dict
+        scope.modules[name] = val
+    else
+        modules = Dict(name => val)
+    end
+end
+
+function _mark_import_arg(arg, par, state, usinged)
     if par !== nothing && (typof(arg) === IDENTIFIER || typof(arg) === MacroName)
         if par isa Binding # mark reference to binding
             push!(par.refs, arg)
@@ -65,31 +73,16 @@ function _mark_import_arg(arg, par, state, u)
             end
             arg.meta.binding = Binding(arg, par, _typeof(par, state), [], nothing, nothing)
         end
-        if u && par isa SymbolServer.ModuleStore
-            if state.scope.modules isa Dict
-                state.scope.modules[Symbol(valof(arg))] = par
-            else
-                state.scope.modules = Dict(Symbol(valof(arg)) => par)
+        if usinged
+            if par isa SymbolServer.ModuleStore
+                add_to_imported_modules(state.scope, Symbol(valof(arg)), par)
+            elseif par isa Binding && par.val isa SymbolServer.ModuleStore 
+                add_to_imported_modules(state.scope, Symbol(valof(arg)), par.val)
+            elseif par isa Binding && par.val isa EXPR && (typof(par.val) === CSTParser.ModuleH || typof(par.val) === CSTParser.BareModule)
+                add_to_imported_modules(state.scope, Symbol(valof(arg)), scopeof(par.val))
+            elseif par isa Binding && par.val isa Binding && par.val.val isa EXPR && (typof(par.val.val) === CSTParser.ModuleH || typof(par.val.val) === CSTParser.BareModule)
+                add_to_imported_modules(state.scope, Symbol(valof(arg)), scopeof(par.val.val))
             end
-        elseif u && par isa Binding && par.val isa SymbolServer.ModuleStore 
-            if state.scope.modules isa Dict
-                state.scope.modules[Symbol(valof(arg))] = par.val
-            else
-                state.scope.modules = Dict(Symbol(valof(arg)) => par.val)
-            end
-        elseif u && par isa Binding && par.val isa EXPR && (typof(par.val) === CSTParser.ModuleH || typof(par.val) === CSTParser.BareModule)
-            if state.scope.modules isa Dict
-                state.scope.modules[Symbol(valof(arg))] = scopeof(par.val)
-            else
-                state.scope.modules = Dict(Symbol(valof(arg)) => scopeof(par.val))
-            end
-        elseif u && par isa Binding && par.val isa Binding && par.val.val isa EXPR && (typof(par.val.val) === CSTParser.ModuleH || typof(par.val.val) === CSTParser.BareModule)
-            if state.scope.modules isa Dict
-                state.scope.modules[Symbol(valof(arg))] = scopeof(par.val.val)
-            else
-                state.scope.modules = Dict(Symbol(valof(arg)) => scopeof(par.val.val))
-            end
-            
         end
     end
 end

--- a/src/references.jl
+++ b/src/references.jl
@@ -201,12 +201,12 @@ function resolve_getfield(x::EXPR, b::Binding, state::State)::Bool
         resolved = resolve_getfield(x, b.type.val, state)
     elseif b.val isa SymbolServer.ModuleStore
         resolved = resolve_getfield(x, b.val, state)
-    elseif b.type isa SymbolServer.DataTypeStore
-        resolved = resolve_getfield(x, b.type, state)
     elseif b.val isa EXPR && CSTParser.defines_module(b.val)
         resolved = resolve_getfield(x, b.val, state)
     elseif b.val isa Binding && b.val.val isa EXPR && CSTParser.defines_module(b.val.val)
         resolved = resolve_getfield(x, b.val.val, state)
+    elseif b.type isa SymbolServer.DataTypeStore
+        resolved = resolve_getfield(x, b.type, state)
     end
     return resolved
 end

--- a/src/references.jl
+++ b/src/references.jl
@@ -177,12 +177,12 @@ function resolve_getindex(x::EXPR, b::Binding, state::State)::Bool
         resolved = resolve_getindex(x, b.type.val, state)
     elseif b.val isa SymbolServer.ModuleStore
         resolved = resolve_getindex(x, b.val, state)
-    elseif b.type isa SymbolServer.DataTypeStore
-        resolved = resolve_getindex(x, b.type, state)
     elseif b.val isa EXPR && (typof(b.val) === ModuleH || typof(b.val) === BareModule)
         resolved = resolve_getindex(x, b.val, state)
     elseif b.val isa Binding && b.val.val isa EXPR && (typof(b.val.val) === ModuleH || typof(b.val.val) === BareModule)
         resolved = resolve_getindex(x, b.val.val, state)
+    elseif b.type isa SymbolServer.DataTypeStore
+        resolved = resolve_getindex(x, b.type, state)
     end
     return resolved
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -14,8 +14,9 @@ mutable struct FileServer <: AbstractServer
     roots::Set{File}
     symbolserver::SymbolServer.EnvStore
     symbol_extends::Dict{SymbolServer.VarRef, Vector{SymbolServer.VarRef}}
+    symbol_fieldtypemap::Dict{Symbol, Vector{SymbolServer.VarRef}}
 end
-FileServer() = FileServer(Dict{String,File}(), Set{File}(), deepcopy(SymbolServer.stdlibs), SymbolServer.collect_extended_methods(SymbolServer.stdlibs))
+FileServer() = FileServer(Dict{String,File}(), Set{File}(), deepcopy(SymbolServer.stdlibs), SymbolServer.collect_extended_methods(SymbolServer.stdlibs), fieldname_type_map(SymbolServer.stdlibs))
 
 # Interface spec.
 # AbstractServer :-> (has/canload/load/set/get)file, getsymbolserver, getsymbolextends
@@ -37,6 +38,7 @@ function loadfile(server::FileServer, path::String)
 end
 getsymbolserver(server::FileServer) = server.symbolserver
 getsymbolextendeds(server::FileServer) = server.symbol_extends
+getsymbolfieldtypemap(server::FileServer) = server.symbol_fieldtypemap
 
 function scopepass(file, target = nothing)
     server = file.server

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -183,5 +183,3 @@ function infer_type_by_getfield_calls(b::Binding, server)
         end
     end
 end
-
-

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -58,3 +58,129 @@ function infer_type(binding::Binding, scope, state)
         end
     end
 end
+
+"""
+    is_getfield_lhs(x::EXPR)
+x the `a` in `a.b`
+"""
+is_getfield_lhs(x::EXPR) = is_getfield(parentof(x)) && x === parentof(x)[1]
+
+"""
+    is_getfield_lhs_as_chain(x::EXPR)
+x the `b` in `a.b.c`
+"""
+is_getfield_lhs_as_chain(x::EXPR) = parentof(x) isa EXPR && typof(parentof(x)) === CSTParser.Quotenode && StaticLint.is_getfield(parentof(parentof(x))) && StaticLint.is_getfield(parentof(parentof(parentof(x)))) && x === parentof(parentof(x))[3][1]
+
+function get_struct_fieldname(x::EXPR)
+    if _binary_assert(x, CSTParser.Tokens.DECLARATION)
+        return get_struct_fieldname(x[1])
+    elseif typof(x) === CSTParser.InvisBrackets && length(x) == 3
+        return get_struct_fieldname(x[2])
+    elseif isidentifier(x)
+        return x
+    else
+    end
+    return nothing
+end
+
+function cst_struct_fieldnames(x::EXPR)
+    fns = Symbol[]
+    if CSTParser.defines_mutable(x)
+        body = x[4]
+    elseif CSTParser.defines_struct(x)
+        body = x[3]
+    else
+        return fns
+    end
+    for arg in body
+        field_name = get_struct_fieldname(arg)
+        if field_name isa EXPR && isidentifier(field_name)
+            push!(fns, Symbol(CSTParser.str_value(field_name)))
+        end
+    end
+    return fns
+end
+
+fieldname_type_map(s, server, l = Dict()) = l # fallback
+function fieldname_type_map(s::Scope, server, l = Dict())
+    for (n,b) in s.names
+        b = get_root_method(b, server)
+        if b isa Binding && b.val isa EXPR && CSTParser.defines_datatype(b.val)
+            for f in cst_struct_fieldnames(b.val)
+                f = Symbol(f)
+                if haskey(l, f)
+                    push!(l[f], b)
+                else
+                    l[f] = [b]
+                end
+            end
+        end
+    end
+    l
+end
+
+function fieldname_type_map(cache::SymbolServer.ModuleStore, l)
+    for (n,v) in cache.vals
+        if v isa SymbolServer.DataTypeStore
+            for f in v.fieldnames
+                if haskey(l, f)
+                    push!(l[f], v.name.name)
+                else
+                    l[f] = [v.name.name]
+                end
+            end
+        elseif v isa SymbolServer.ModuleStore
+            fieldname_type_map(v, l)
+        end
+    end
+    l
+end
+
+function fieldname_type_map(cache::SymbolServer.EnvStore, l = Dict())
+    for (_,m) in cache
+        fieldname_type_map(m, l)
+    end
+    l
+end
+
+function infer_type_by_getfield_calls(b::Binding, server)
+    b.type !== nothing && return # b already has a type
+    user_datatypes = fieldname_type_map(retrieve_toplevel_scope(b.val), server)
+    possibletypes = []
+    for ref in b.refs
+        ref isa EXPR || continue # skip non-EXPR (i.e. used for handling of globals)
+        if is_getfield_lhs(ref) && typof(parentof(ref)[3]) === CSTParser.Quotenode
+            rhs = parentof(ref)[3][1]
+        elseif is_getfield_lhs_as_chain(ref)
+            rhs = parentof(parentof(parentof(ref)))[3][1]
+        else
+            continue
+        end
+        
+        if isidentifier(rhs)
+            rhs_sym = Symbol(CSTParser.str_value(rhs))
+            new_possibles = [get(getsymbolfieldtypemap(server), rhs_sym, [])..., get(user_datatypes, rhs_sym, [])...]
+
+            # @info new_possibles
+            if isempty(possibletypes)
+                possibletypes = new_possibles
+            elseif !isempty(new_possibles)
+                possibletypes = intersect(possibletypes, new_possibles)
+            end
+            if isempty(possibletypes)
+                return
+            end
+        end
+    end
+    if length(possibletypes) == 1
+        type = first(possibletypes)
+        if type isa Binding
+            b.type = type
+        elseif type isa SymbolServer.VarRef
+            b.type = SymbolServer._lookup(type, getsymbolserver(server)) # could be nothing
+        else
+        end
+    end
+end
+
+

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -276,7 +276,8 @@ isexportedby(k::String, m::SymbolServer.ModuleStore) = isexportedby(Symbol(k), m
 isexportedby(x::EXPR, m::SymbolServer.ModuleStore) = isexportedby(valof(x), m)
 isexportedby(k, m::SymbolServer.ModuleStore) = false
 
-function retrieve_toplevel_scope(x)
+function retrieve_toplevel_scope(x) end
+function retrieve_toplevel_scope(x::EXPR)
     if scopeof(x) !== nothing && (typof(x) === CSTParser.ModuleH || typof(x) === CSTParser.BareModule || typof(x) === CSTParser.FileH)
         return scopeof(x)
     elseif parentof(x) isa EXPR

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -119,6 +119,18 @@ function get_root_method(b::Binding, server, b1 = nothing, visited_bindings = Bi
     end
 end
 
+function get_last_method(b::Binding, server, visited_bindings = Binding[])
+    if b.next === nothing || b == b.next || !(b.next isa Binding) || b in visited_bindings
+        return b
+    end
+    push!(visited_bindings, b)
+    if b.type == b.next.type == CoreTypes.Function
+        return get_last_method(b.next, server, visited_bindings)
+    else
+        return b
+    end
+end
+
 function retrieve_delayed_scope(x)
     if (CSTParser.defines_function(x) || CSTParser.defines_macro(x)) && scopeof(x) !== nothing
         if parentof(scopeof(x)) !== nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ function parse_and_pass(s)
     f = StaticLint.File("", s, CSTParser.parse(s, true), nothing, server)
     StaticLint.setroot(f, f)
     StaticLint.setfile(server, "", f)
-    StaticLint.scopepass(f)
+    StaticLint.scopepass(f, f)
     return f.cst
 end
 
@@ -768,44 +768,5 @@ end
     end
 end
 
-
-
-@testset "fieldname inference" begin
-    let cst = parse_and_pass("""
-        struct T
-            fieldname1
-        end
-        struct S
-            fieldname2
-        end
-        function f(arg1, arg2, arg3)
-            arg1.fieldname1
-            arg2.fieldname2
-            arg3.fieldname1
-            arg3.fieldname2
-        end
-        """)
-        @test bindingof(cst[3][2][3]).type !== nothing
-        @test bindingof(cst[3][2][5]).type !== nothing
-        @test bindingof(cst[3][2][7]).type === nothing
-    end
-    let cst = parse_and_pass("""
-        struct T
-            fieldname1
-        end
-        struct S
-            fieldname2
-        end
-        function f(arg1)
-            if arg1 isa T
-                arg1.fieldname1
-            elseif arg1 isa S
-                arg1.fieldname2
-            end
-        end
-        """)
-        @test bindingof(cst[3][2][3]).type === nothing
-    end
-end
-
+include("type_inf.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -792,3 +792,4 @@ end
 
 include("type_inf.jl")
 end
+end

--- a/test/type_inf.jl
+++ b/test/type_inf.jl
@@ -1,0 +1,138 @@
+@testset "fieldname inference" begin
+# arg1 is inferred as T -> only a single (user defined) 
+# datatype has the field `fieldname1`
+let cst = parse_and_pass("""
+    struct T
+        fieldname1
+    end
+    function f(arg1)
+        arg1.fieldname1
+    end
+    """)
+    @test cst[2].meta.scope.names["arg1"].type === cst.meta.scope.names["T"]
+end
+
+# arg1 inferred as above
+# arg2 as above but for `S`
+# arg3 field use is conflicting -> no type assigned
+let cst = parse_and_pass("""
+    struct T
+        fieldname1
+    end
+    struct S
+        fieldname2
+    end
+    function f(arg1, arg2, arg3)
+        arg1.fieldname1
+        arg2.fieldname2
+        arg3.fieldname1
+        arg3.fieldname2
+    end
+    """)
+    @test cst[3].meta.scope.names["arg1"].type === cst.meta.scope.names["T"]
+    @test cst[3].meta.scope.names["arg2"].type === cst.meta.scope.names["S"]
+    @test cst[3].meta.scope.names["arg3"].type === nothing
+end
+
+# arg1 type inferred as above
+# arg2 type  not inferred as `sig` is also the fieldname of
+# `Method` exported by Core.
+let cst = parse_and_pass("""
+    struct T
+        fieldname1
+        sig
+    end
+    function f(arg1, arg2)
+        arg1.fieldname1
+        arg2.sig
+    end
+    """)
+    @test cst[2].meta.scope.names["arg1"].type === cst.meta.scope.names["T"]
+    @test cst[2].meta.scope.names["arg2"].type === nothing
+end
+
+let cst = parse_and_pass("""
+    struct T
+        fieldname1
+    end
+    struct S
+        fieldname2
+    end
+    function f(arg1)
+        if arg1 isa T
+            arg1.fieldname1
+        elseif arg1 isa S
+            arg1.fieldname2
+        end
+    end
+    """)
+    @test cst[3].meta.scope.names["arg1"].type === nothing
+end
+end
+
+@testset "inference by use as function argument" begin
+# single method function with user defined datatype
+let cst = parse_and_pass("""
+    struct T end
+    function f(arg::T) end
+    function g(arg) end
+    let arg1 = unknownvalue, arg2 = unknownvalue
+        f(arg1)
+        g(arg1)
+    end
+    """)
+    @test cst[4].meta.scope.names["arg1"].type === cst.meta.scope.names["T"]
+    @test cst[4].meta.scope.names["arg2"].type === nothing
+end
+
+# as above against imported (symbolserver) types
+let cst = parse_and_pass("""
+    function f(arg::Int) end
+    let arg = unknownvalue
+        f(arg)
+    end
+    """)
+    @test cst[2].meta.scope.names["arg"].type.name == SymbolServer.FakeTypeName(Int)
+end
+
+# 2 methods, conflicting types so no inference
+let cst = parse_and_pass("""
+    function f(arg::Int) end
+    function f(arg::Float64) end
+    let arg = unknownvalue
+        f(arg)
+    end
+    """)
+    @test cst[3].meta.scope.names["arg"].type === nothing
+end
+
+# 2 functions, 1 with two methods. 
+let cst = parse_and_pass("""
+    function f(arg::Int) end
+    function f(arg::Float64) end
+    function g(arg::Int) end
+    let arg = unknownvalue
+        f(arg)
+        g(arg)
+    end
+    """)
+    @test cst[4].meta.scope.names["arg"].type.name == SymbolServer.FakeTypeName(Int)
+end
+
+# SymServer function w/ single method 
+let cst = parse_and_pass("""
+    let arg = unknownvalue
+        dirname(arg)
+    end
+    """)
+    @test cst[1].meta.scope.names["arg"].type.name == SymbolServer.FakeTypeName(AbstractString)
+end
+# As above but qualified name for function.
+let cst = parse_and_pass("""
+    let arg = unknownvalue
+        Base.dirname(arg)
+    end
+    """)
+    @test cst[1].meta.scope.names["arg"].type.name == SymbolServer.FakeTypeName(AbstractString)
+end
+end


### PR DESCRIPTION
This adds another inference pass to non-toplevel scopes. Type information is added for bindings where `getfield` is used on the variable through the dot operator.

```julia
struct T
    somefieldname1
end
struct S
    somefieldname1
    somefieldname2
end
function f(arg1, arg2, arg3)
   arg1.somefieldname1 + arg1.somefieldname2
   arg2.somefieldname2
   arg3.somefieldname1
end
```

In the above example `arg1` and `arg2` would be inferred as `S` (`arg3` could not be inferred due to `somefieldname1` exists across both types. A map of fieldnames-to-datatype for the symbolserver cache is stored. Repeated construction of the equivalent map for the top-level scope can be improved on. 

This is a considerably different approach to how we currently do our limited inference (i.e. its a bit more speculative) so is worthy of discussion before I get too involved in exploring this.