### PR TITLE
Remove setpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ An `AbstractFile` must support the following:
 
 `StaticLint.getpath(file)` : Retrieve the path of a file.
 
-`StaticLint.setpath(file, path)` : Set the path of a file.
-
 `StaticLint.getroot(file)` : Retrieve the root of a file. The root is the main/first file in a file structure. For example the `StaticLint.jl` file is the root of all files (including itself) in `src/`.
 
 `StaticLint.setroot(file, root)` : Set the root of a file.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -66,8 +66,6 @@ An `AbstractFile` must support the following:
 
 `StaticLint.getpath(file)` : Retrieve the path of a file.
 
-`StaticLint.setpath(file, path)` : Set the path of a file.
-
 `StaticLint.getroot(file)` : Retrieve the root of a file. The root is the main/first file in a file structure. For example the `StaticLint.jl` file is the root of all files (including itself) in `src/`.
 
 `StaticLint.setroot(file, root)` : Set the root of a file.

--- a/src/server.jl
+++ b/src/server.jl
@@ -52,10 +52,6 @@ function scopepass(file, target = nothing)
 end
 
 getpath(file::File) = file.path
-function setpath(file::File, path)
-    file.path = path
-    return file
-end
 
 getroot(file::File) = file.root
 function setroot(file::File, root::File)


### PR DESCRIPTION
This seems to be not used anywhere, so we might as well remove it?

There is more coming, we generally need to rethink a bit how we think about paths here because we have a hard assumption baked in that we can construct a path for all files that are opened currently, which is not the case. More PRs to other packages coming :)