### PR TITLE
Enable missing ref errors for getfields

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 julia = "1"
 CSTParser = "2.1"
-SymbolServer = "4.1"
+SymbolServer = "4.3"
 
 [targets]
 test = ["Test", "Pkg", "SHA", "LibGit2"]

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -444,7 +444,7 @@ function check_all(x::EXPR, opts::LintOptions, server)
 end
 
 
-function collect_hints(x::EXPR, missing = true, isquoted = false, errs = Tuple{Int,EXPR}[], pos = 0)
+function collect_hints(x::EXPR, server, missing = true, isquoted = false, errs = Tuple{Int,EXPR}[], pos = 0)
     if quoted(x)
         isquoted = true
     elseif isquoted && unquoted(x)
@@ -462,15 +462,12 @@ function collect_hints(x::EXPR, missing = true, isquoted = false, errs = Tuple{I
             # collect lint hints
             push!(errs, (pos, x))
         end
-    elseif isquoted && should_mark_missing_getfield_ref(x)
-        lhsref = refof_maybe_getfield(parentof(parentof(x))[1])
-        if getfield_should_be_resolved(lhsref)
+    elseif isquoted && should_mark_missing_getfield_ref(x, server)
             push!(errs, (pos, x))
-        end
     end
 
     for i in 1:length(x)
-        collect_hints(x[i], missing, isquoted, errs, pos)
+        collect_hints(x[i], server, missing, isquoted, errs, pos)
         pos += x[i].fullspan
     end
     
@@ -485,16 +482,80 @@ function refof_maybe_getfield(x::EXPR)
     end
 end
 
-function should_mark_missing_getfield_ref(x)
-    CSTParser.isidentifier(x) && !hasref(x) && 
-    parentof(x) isa EXPR && typof(parentof(x)) === CSTParser.Quotenode && parentof(parentof(x)) isa EXPR && is_getfield(parentof(parentof(x))) 
+function should_mark_missing_getfield_ref(x, server)
+    if CSTParser.isidentifier(x) && !hasref(x) && # x has no ref
+    parentof(x) isa EXPR && typof(parentof(x)) === CSTParser.Quotenode && parentof(parentof(x)) isa EXPR && 
+        is_getfield(parentof(parentof(x)))  # x is the rhs of a getproperty
+        lhsref = refof_maybe_getfield(parentof(parentof(x))[1])
+        if lhsref isa SymbolServer.ModuleStore || (lhsref isa Binding && lhsref.val isa SymbolServer.ModuleStore) 
+            # a module, we should know this.
+            return true
+        elseif lhsref isa Binding
+            if lhsref.val isa Binding
+                lhsref = lhsref.val
+            end
+            lhsref = get_root_method(lhsref, nothing)
+            if lhsref.type isa SymbolServer.DataTypeStore && !(isempty(lhsref.type.fieldnames) || isunionfaketype(lhsref.type.name) || has_getproperty_method(lhsref.type, server))
+                return true
+            elseif lhsref.type isa Binding && lhsref.type.val isa EXPR && CSTParser.defines_struct(lhsref.type.val) && !has_getproperty_method(lhsref.type)
+                return true
+            end
+        end
+    end
+    return false
 end
 
-function getfield_should_be_resolved(lhsref)
-    lhsref isa SymbolServer.ModuleStore ||
-            (lhsref isa Binding && lhsref.val isa SymbolServer.ModuleStore) ||
-            (lhsref isa Binding && lhsref.type isa SymbolServer.DataTypeStore && !(isempty(lhsref.type.fieldnames) || isunionfaketype(lhsref.type.name))) ||
-            (lhsref isa Binding && lhsref.type isa Binding && lhsref.type.val isa EXPR && CSTParser.defines_struct(lhsref.type.val))
+unwrap_fakeunionall(x) = x isa SymbolServer.FakeUnionAll ? unwrap_fakeunionall(x.body) : x
+function has_getproperty_method(b::SymbolServer.DataTypeStore, server)
+    getprop_vr = SymbolServer.VarRef(SymbolServer.VarRef(nothing, :Base), :getproperty)
+    if haskey(getsymbolextendeds(server), getprop_vr)
+        for ext in getsymbolextendeds(server)[getprop_vr]
+            for m in SymbolServer._lookup(ext, getsymbolserver(server))[:getproperty].methods
+                t = unwrap_fakeunionall(m.sig[1][2])
+                t.name == b.name.name && return true
+            end
+        end
+    else
+        for m in getsymbolserver(server)[:Base][:getproperty].methods
+            t = unwrap_fakeunionall(m.sig[1][2])
+            t.name == b.name.name && return true
+        end
+    end
+    return false
+end
+
+function has_getproperty_method(b::Binding)
+    if b.val isa Binding
+        return has_getproperty_method(b.val)
+    elseif b.val isa SymbolServer.DataTypeStore
+        return has_getproperty_method(b.val)
+    elseif  b isa Binding && b.type === CoreTypes.DataType
+        while b !== nothing
+            for ref in b.refs
+                if is_type_of_call_to_getproperty(ref)
+                    return true
+                end
+            end
+            b = b.next isa Binding && b.next.type === CoreTypes.Function ? b.next : nothing
+        end
+        
+    end
+    return false
+end
+
+function is_type_of_call_to_getproperty(x::EXPR)
+    function is_call_to_getproperty(x::EXPR) 
+        if typof(x) === CSTParser.Call 
+            func_name = x[1]
+            return (isidentifier(func_name) && valof(func_name) == "getproperty") || # getproperty()
+            (is_getfield_w_quotenode(func_name) && isidentifier(func_name[3][1]) && valof(func_name[3][1]) == "getproperty") # Base.getproperty()
+        end
+        return false
+    end
+
+    return parentof(x) isa EXPR && parentof(parentof(x)) isa EXPR && 
+        ((_binary_assert(parentof(x), CSTParser.Tokens.DECLARATION) && x === parentof(x)[3] && is_call_to_getproperty(parentof(parentof(x)))) || 
+        (typof(parentof(x)) === CSTParser.Curly && x === parentof(x)[1] && _binary_assert(parentof(parentof(x)), CSTParser.Tokens.DECLARATION) &&  parentof(parentof(parentof(x))) isa EXPR && is_call_to_getproperty(parentof(parentof(parentof(x))))))
 end
 
 isunionfaketype(t::SymbolServer.FakeTypeName) = t.name.name === :Union && t.name.parent isa SymbolServer.VarRef && t.name.parent.name === :Core

--- a/src/references.jl
+++ b/src/references.jl
@@ -197,16 +197,14 @@ end
 function resolve_getfield(x::EXPR, b::Binding, state::State)::Bool
     hasref(x) && return true
     resolved = false
-    if b.type isa Binding
-        resolved = resolve_getfield(x, b.type.val, state)
-    elseif b.val isa SymbolServer.ModuleStore
+    if b.val isa Binding
         resolved = resolve_getfield(x, b.val, state)
+    elseif b.val isa SymbolServer.ModuleStore || ( b.val isa EXPR && CSTParser.defines_module(b.val))
+        resolved = resolve_getfield(x, b.val, state)
+    elseif b.type isa Binding
+        resolved = resolve_getfield(x, b.type.val, state)
     elseif b.type isa SymbolServer.DataTypeStore
         resolved = resolve_getfield(x, b.type, state)
-    elseif b.val isa EXPR && CSTParser.defines_module(b.val)
-        resolved = resolve_getfield(x, b.val, state)
-    elseif b.val isa Binding && b.val.val isa EXPR && CSTParser.defines_module(b.val.val)
-        resolved = resolve_getfield(x, b.val.val, state)
     end
     return resolved
 end

--- a/src/references.jl
+++ b/src/references.jl
@@ -217,8 +217,7 @@ end
 function resolve_getfield(x::EXPR, m::SymbolServer.ModuleStore, state::State)::Bool
     hasref(x) && return true
     resolved = false
-    if CSTParser.isidentifier(x) && haskey(m, Symbol(valof(x)))
-        val = m[Symbol(valof(x))]
+    if CSTParser.isidentifier(x) && (val = SymbolServer.maybe_getfield(Symbol(CSTParser.str_value(x)), m, getsymbolserver(state.server))) !== nothing
         if val isa SymbolServer.VarRef
             val = SymbolServer._lookup(val, getsymbolserver(state.server))
             !(val isa SymbolServer.SymStore) && return false


### PR DESCRIPTION
This marks the rhs of getfield (`a.b`) calls as errors where we can determine what fields the lhs should have. 

This is ready to go but has highlighted several issues with how we handle the namespaces of modules imported by a SymbolServer cache. 

Requires https://github.com/julia-vscode/SymbolServer.jl/pull/147, a ver bump on SymServ then updated Project.toml