### PR TITLE
Split toplevel and delayed passes

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -40,23 +40,18 @@ hasscope(m::Meta) = m.scope isa Scope
 scopeof(m::Meta) = m.scope
 bindingof(m::Meta) = m.binding
 
-mutable struct State{T}
+abstract type State end
+mutable struct Toplevel{T} <: State
     file::T
     targetfile::Union{Nothing,T}
     included_files::Vector{String}
     scope::Scope
-    delayed::Bool
-    urefs::Vector{EXPR}
+    delayed::Vector{EXPR}
     server
 end
 
-function (state::State)(x::EXPR)
-    delayed = state.delayed # store states
-    
+function (state::Toplevel)(x::EXPR)
     resolve_import(x, state)
-    if typof(x) === Export # Allow delayed resolution
-        state.delayed = true
-    end
     mark_bindings!(x, state)
     add_binding(x, state)
     mark_globals(x, state)
@@ -65,11 +60,32 @@ function (state::State)(x::EXPR)
     _resolve_ref(x, state)
     followinclude(x, state)
 
-    traverse(x, state)
+    if CSTParser.defines_function(x) || CSTParser.defines_macro(x) || typof(x) === CSTParser.Export
+        push!(state.delayed, x)
+    else
+        traverse(x, state)
+    end
 
-    # return to previous states
     state.scope != s0 && (state.scope = s0)
-    state.delayed = delayed
+    return state.scope
+end
+
+mutable struct Delayed <: State
+    scope::Scope
+    server
+end
+
+function (state::Delayed)(x::EXPR)
+    mark_bindings!(x, state)
+    add_binding(x, state)
+    mark_globals(x, state)
+    handle_macro(x, state)
+    s0 = scopes(x, state)
+    _resolve_ref(x, state)
+
+    traverse(x, state)
+    
+    state.scope != s0 && (state.scope = s0)
     return state.scope
 end
 

--- a/src/references.jl
+++ b/src/references.jl
@@ -21,9 +21,6 @@ end
 function _resolve_ref(x, state)
     if !(parentof(x) isa EXPR && typof(parentof(x)) == CSTParser.Quotenode)
         resolved = resolve_ref(x, state.scope, state, [])
-        if !resolved && (state.delayed || isglobal(valof(x), state.scope))
-            push!(state.urefs, x)
-        end
     end
 end
 

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -115,9 +115,6 @@ function scopes(x::EXPR, state)
     if typof(x) === FileH
         setscope!(x, state.scope)
     elseif scopeof(x) isa Scope
-        if CSTParser.defines_function(x) || CSTParser.defines_macro(x)
-            state.delayed = true # Allow delayed resolution
-        end
         scopeof(x) != s0 && setparent!(scopeof(x), s0)
         state.scope = scopeof(x)
         if typof(x) === ModuleH # Add default modules to a new module

--- a/src/server.jl
+++ b/src/server.jl
@@ -41,12 +41,14 @@ getsymbolextendeds(server::FileServer) = server.symbol_extends
 function scopepass(file, target = nothing)
     server = file.server
     setscope!(getcst(file), Scope(nothing, getcst(file), Dict(), Dict{Symbol,Any}(:Base => getsymbolserver(server)[:Base], :Core => getsymbolserver(server)[:Core]), false))
-    state = State(file, target, [getpath(file)], scopeof(getcst(file)), false, EXPR[], server)
+    state = Toplevel(file, target, [getpath(file)], scopeof(getcst(file)), EXPR[], server)
     state(getcst(file))
-    for uref in state.urefs
-        s = retrieve_delayed_scope(uref)
-        if s !== nothing
-            resolve_ref(uref, s, state, [])
+    for x in state.delayed
+        if hasscope(x)
+            traverse(x, Delayed(scopeof(x), server))
+        else 
+            ds = retrieve_delayed_scope(x)
+            traverse(x, Delayed(ds, server))
         end
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -126,10 +126,8 @@ function retrieve_delayed_scope(x)
         else
             return scopeof(x)
         end
-    elseif typof(x) === Export
+    else 
         return retrieve_scope(x)
-    elseif parentof(x) !== nothing
-        return retrieve_delayed_scope(parentof(x))
     end
     return nothing
 end


### PR DESCRIPTION
This splits the pass across CST carried out by SL into two distinct stages. First there is a toplevel pass which pushes all delayed scopes (i.e. functions, macros and export statements) to a list which are then resolved afterwards. Importantly, thiis second stage should be able to be done concurrently.