### PR TITLE
Add constructor for LintOptions that coalesces nothing

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -444,7 +444,7 @@ end
 
 const default_options = (false, true, false, true, true, false, true, true, true, true)
 
-mutable struct LintOptions
+struct LintOptions
     call::Bool
     iter::Bool
     nothingcomp::Bool

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -442,6 +442,7 @@ function check_farg_unused(x::EXPR)
     end
 end
 
+const default_options = (false, true, false, true, true, false, true, true, true, true)
 
 mutable struct LintOptions
     call::Bool
@@ -455,11 +456,11 @@ mutable struct LintOptions
     pirates::Bool
     useoffuncargs::Bool
 end
-LintOptions() = LintOptions(true, true, true, true, true, false, true, true, true, true)
+LintOptions() = LintOptions(default_options...)
+LintOptions(::Colon) = LintOptions(fill(true, length(default_options))...)
 
-# Default all linting options on
-LintOptions(options::Vararg{Union{Bool,Nothing},9}) =
-    LintOptions(something.(options, true))
+LintOptions(options::Vararg{Union{Bool,Nothing},length(default_options)}) =
+    LintOptions(something.(options, default_options)...)
 
 function check_all(x::EXPR, opts::LintOptions, server)
     # Do checks

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -457,6 +457,10 @@ mutable struct LintOptions
 end
 LintOptions() = LintOptions(true, true, true, true, true, false, true, true, true, true)
 
+# Default all linting options on
+LintOptions(options::Vararg{Union{Bool,Nothing},9}) =
+    LintOptions(something.(options, true))
+
 function check_all(x::EXPR, opts::LintOptions, server)
     # Do checks
     opts.call && check_call(x, server)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -287,7 +287,7 @@ f(arg) = arg
     let cst = parse_and_pass("""
         sin(1,2,3)
         """)
-        check_all(cst, StaticLint.LintOptions(),server)
+        check_all(cst, StaticLint.LintOptions(:),server)
         @test errorof(cst[1]) === StaticLint.IncorrectCallArgs
     end
     let cst = parse_and_pass("""
@@ -296,7 +296,7 @@ f(arg) = arg
         for i in 1 end
         for i in 1:1 end
         """)
-        check_all(cst, StaticLint.LintOptions(),server)
+        check_all(cst, StaticLint.LintOptions(:),server)
         @test errorof(cst[1][2]) === StaticLint.IncorrectIterSpec
         @test errorof(cst[2][2]) === StaticLint.IncorrectIterSpec
         @test errorof(cst[3][2]) === StaticLint.IncorrectIterSpec
@@ -309,7 +309,7 @@ f(arg) = arg
         [i for i in 1 end]
         [i for i in 1:1 end]
         """)
-        check_all(cst, StaticLint.LintOptions(),server)
+        check_all(cst, StaticLint.LintOptions(:),server)
         @test errorof(cst[1][2][3]) === StaticLint.IncorrectIterSpec
         @test errorof(cst[2][2][3]) === StaticLint.IncorrectIterSpec
         @test errorof(cst[3][2][3]) === StaticLint.IncorrectIterSpec
@@ -317,7 +317,7 @@ f(arg) = arg
     end
 
     let cst = parse_and_pass("a == nothing")
-        check_all(cst, StaticLint.LintOptions(),server)
+        check_all(cst, StaticLint.LintOptions(:),server)
         @test errorof(cst[1][2]) === StaticLint.NothingEquality 
     end
 
@@ -406,7 +406,7 @@ end
         f() where {T,S}
         f() where {T<:Any}
         """)
-        StaticLint.check_all(cst, StaticLint.LintOptions(), server)
+        StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
         @test StaticLint.errorof(cst[1][3]) == StaticLint.UnusedTypeParameter
         @test StaticLint.errorof(cst[2][4]) == StaticLint.UnusedTypeParameter
         @test StaticLint.errorof(cst[2][6]) == StaticLint.UnusedTypeParameter
@@ -417,7 +417,7 @@ end
         f(x::T,y::S) where {T,S}
         f(x::T) where {T<:Any}
         """)
-        StaticLint.check_all(cst, StaticLint.LintOptions(), server)
+        StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
         @test !StaticLint.haserror(cst[1][3])
         @test !StaticLint.haserror(cst[2][4])
         @test !StaticLint.haserror(cst[2][6])


### PR DESCRIPTION
Any field of LintOptions set to nothing will be set to default value

This is for fixing https://github.com/julia-vscode/LanguageServer.jl/issues/624