### PR TITLE
turn checks on by default, add missingref options

### DIFF
--- a/src/references.jl
+++ b/src/references.jl
@@ -237,10 +237,9 @@ function resolve_getfield(x::EXPR, parent::SymbolServer.DataTypeStore, state::St
         fi = findfirst(f->Symbol(valof(x)) == f, parent.fieldnames)
         ft = parent.types[fi]
         val = SymbolServer._lookup(ft, getsymbolserver(state.server))
-        if val !== nothing
-            setref!(x, Binding(noname, nothing, val, [], nothing, nothing))
-            resolved = true
-        end
+        # TODO: Need to handle the case where we get back a FakeUnion, etc.
+        setref!(x, Binding(noname, nothing, val, [], nothing, nothing))
+        resolved = true
     end
     return resolved
 end


### PR DESCRIPTION
Turn on everything by default - if it's in there it should be used and fi it doesn't work for people (literal bugs or just isn't useful) this way we get feedback.

Also fixes a resolve_getfield issue