### PR TITLE
Add rudimentary handling for `@eval`

### DIFF
--- a/src/imports.jl
+++ b/src/imports.jl
@@ -87,11 +87,23 @@ function add_to_imported_modules(scope::Scope, name::Symbol, val)
         modules = Dict(name => val)
     end
 end
-
+no_modules_above(s::Scope) = !CSTParser.defines_module(s.expr) || s.parent === nothing || no_modules_above(s.parent)
+function get_named_toplevel_module(s::Scope, name::String) 
+    if s.ismodule && valofid(CSTParser.get_name(s.expr)) == name && no_modules_above(s)
+        return s.expr
+    elseif s.parent isa Scope
+        return get_named_toplevel_module(s.parent, name)
+    end
+    return nothing
+end
 function _get_field(par, arg, state)
     arg_str_rep = CSTParser.str_value(arg)
-    if par isa SymbolServer.EnvStore && haskey(par, Symbol(arg_str_rep))
-        return par[Symbol(arg_str_rep)]
+    if par isa SymbolServer.EnvStore 
+        if (tlm = get_named_toplevel_module(retrieve_scope(arg), arg_str_rep)) !== nothing && hasbinding(tlm)
+            return bindingof(tlm)
+        elseif haskey(par, Symbol(arg_str_rep))
+            return par[Symbol(arg_str_rep)]
+        end
     elseif par isa SymbolServer.ModuleStore # imported module
         if Symbol(arg_str_rep) === par.name.name
             return par

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -208,8 +208,9 @@ function check_call(x, server)
         # find the function we're dealing with
         if isidentifier(first(x)) && hasref(first(x))
             func_ref = refof(first(x))
-        elseif is_binary_call(x[1], CSTParser.Tokens.DOT) && typof(x[1]) === CSTParser.Quotenode && length(x[1][3]) > 0 && isidentifier(x[1][3][1]) && hasref(first(x)[3][1])
-            func_ref = refof(first(last(first(x))))
+            # elseif is_binary_call(x[1], CSTParser.Tokens.DOT) && typof(x[1]) === CSTParser.Quotenode && length(x[1][3]) > 0 && isidentifier(x[1][3][1]) && hasref(first(x)[3][1])
+        elseif is_getfield_w_quotenode(x[1]) && (rhs = rhs_of_getfield(x[1])) !== nothing && hasref(rhs)
+            func_ref = refof(rhs)
         else
             return
         end

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -193,10 +193,19 @@ function compare_f_call(m_counts::Tuple{Int,Int,Array{Symbol},Bool}, call_counts
     return true
 end
 
+function is_something_with_methods(x::Binding)
+    (x.type == CoreTypes.Function && x.val isa EXPR) ||
+    (x.type == CoreTypes.DataType && x.val isa EXPR && CSTParser.defines_struct(x.val)) ||
+    (x.val isa SymbolServer.FunctionStore || x.val isa SymbolServer.DataTypeStore)
+end
+is_something_with_methods(x::T) where T <: Union{SymbolServer.FunctionStore,SymbolServer.DataTypeStore} = true
+is_something_with_methods(x) = false
+
 function check_call(x, server)
     if is_call(x)
         parentof(x) isa EXPR && typof(parentof(x)) === CSTParser.Do && return # TODO: add number of args specified in do block.
         length(x) == 0 && return
+        # find the function we're dealing with
         if isidentifier(first(x)) && hasref(first(x))
             func_ref = refof(first(x))
         elseif is_binary_call(x[1], CSTParser.Tokens.DOT) && typof(x[1]) === CSTParser.Quotenode && length(x[1][3]) > 0 && isidentifier(x[1][3][1]) && hasref(first(x)[3][1])
@@ -204,66 +213,57 @@ function check_call(x, server)
         else
             return
         end
-        if func_ref isa SymbolServer.FunctionStore || func_ref isa SymbolServer.DataTypeStore
-            call_counts = call_nargs(x)
-            function ff(m)
-                m_counts = func_nargs(m)
-                return compare_f_call(m_counts, call_counts)
-            end
-            tls = retrieve_toplevel_scope(x)
-            tls === nothing && return
-            iterate_over_ss_methods(func_ref, tls, server, ff) && return # returns if ff(m) == true for any methods
-            seterror!(x, IncorrectCallArgs)
-        elseif func_ref isa Binding && (func_ref.type === CoreTypes.Function || func_ref.type === CoreTypes.DataType)
-            call_counts = call_nargs(x)
-            function ff1(m)
-                m_counts = func_nargs(m)
-                return compare_f_call(m_counts, call_counts)
-            end
-            b = func_ref
-            seen = Binding[]
-            while b.next isa Binding && b.next.type == CoreTypes.Function && !(b in seen)
-                push!(seen, b)
-                b = b.next
-            end
-            seen = Binding[]
-            while true
-                b in seen && break
-                if !(b isa Binding) # Needs to be cleaned up
-                    if b isa SymbolServer.FunctionStore || b isa SymbolServer.DataTypeStore
-                        tls = retrieve_toplevel_scope(x)
-                        tls === nothing && return 
-                        iterate_over_ss_methods(b, tls, server, ff1) && return
-                        break
-                    else
-                        return
-                    end
-                elseif b.type == CoreTypes.Function && b.val isa EXPR
-                    m_counts = func_nargs(b.val)
-                elseif b.type == CoreTypes.DataType && b.val isa EXPR && CSTParser.defines_struct(b.val)
-                    m_counts = struct_nargs(b.val)
-                elseif b.val isa SymbolServer.FunctionStore || b.val isa SymbolServer.DataTypeStore
-                    tls = retrieve_toplevel_scope(x)
-                    tls === nothing && return 
-                    iterate_over_ss_methods(b.val, tls, server, ff1) && return
-                    break
-                else
-                    break
-                end
-                if compare_f_call(m_counts, call_counts)
-                    return
-                elseif CSTParser.rem_where_decl(CSTParser.get_sig(b.val)) == x
-                    return
-                end
-                b.prev === nothing && break
-                b in seen && break
-                push!(seen, b)
-                b = b.prev
-            end
-            seterror!(x, IncorrectCallArgs)
+
+        if func_ref isa Binding && (func_ref.type === CoreTypes.Function || func_ref.type === CoreTypes.DataType)
+            func_ref = last_method(func_ref)
+        elseif func_ref isa SymbolServer.FunctionStore || func_ref isa SymbolServer.DataTypeStore
+            # intentionally empty
+        else
+            return
         end
+        call_counts = call_nargs(x)
+        tls = retrieve_toplevel_scope(x)
+        tls === nothing && return # General check, this means something serious has gone wrong.
+        !sig_match_any(func_ref, x, call_counts, tls, server) && seterror!(x, IncorrectCallArgs)
+
     end
 end
+
+function sig_match_any(func_ref, x, call_counts, tls, server, visited = [])
+    if func_ref in visited
+        return true
+    else
+        push!(visited, func_ref)
+    end
+    if func_ref isa Binding && (func_ref.val isa SymbolServer.FunctionStore || func_ref.val isa SymbolServer.DataTypeStore)
+        func_ref = func_ref.val
+    end
+    if func_ref isa SymbolServer.FunctionStore || func_ref isa SymbolServer.DataTypeStore
+        return iterate_over_ss_methods(func_ref, tls, server, m->compare_f_call(func_nargs(m), call_counts))
+    elseif func_ref isa Binding
+        if func_ref.type == CoreTypes.Function && func_ref.val isa EXPR
+            m_counts = func_nargs(func_ref.val)
+        elseif func_ref.type == CoreTypes.DataType && func_ref.val isa EXPR && CSTParser.defines_struct(func_ref.val)
+            m_counts = struct_nargs(func_ref.val)
+        else 
+            # We shouldn't get here
+            return true
+        end
+        if compare_f_call(m_counts, call_counts) || (CSTParser.rem_where_decl(CSTParser.get_sig(func_ref.val)) == x)
+            return true
+        end
+        if is_something_with_methods(func_ref.prev)
+            return sig_match_any(func_ref.prev, x, call_counts, tls, server, visited)
+        elseif func_ref.prev isa Binding && func_ref.prev.type === nothing && func_ref.prev.val isa EXPR && isidentifier(func_ref.prev.val) &&
+            isdocumented(func_ref.prev.val) #&& is_something_with_methods(func_ref.prev.prev)
+            # Skip over documented symbols
+            return sig_match_any(func_ref.prev.prev, x, call_counts, tls, server, visited)
+        end
+    end
+    return false
+end
+
+isdocumented(x::EXPR) = parentof(x) isa EXPR && is_macro_call(parentof(x)) && typof(parentof(x)[1]) === CSTParser.GlobalRefDoc
 
 function check_loop_iter(x::EXPR, server)
     if typof(x) === CSTParser.For
@@ -307,22 +307,6 @@ function _get_top_binding(x::EXPR, name::String)
     else
         return nothing
     end
-end
-# Given the name of a function binding lookup the last declared method (i.e. the one 
-# stored in the scope)
-_get_last_method(x, b::Binding, server) = b
-
-function _get_last_method(x::EXPR, b::Binding, server)
-    if scopeof(x) isa Scope
-        if scopehasbinding(scopeof(x), b.name)
-            if scopeof(x).names[b.name] isa Binding && scopeof(x).names[b.name].type == b.type
-                return scopeof(x).names[b.name]
-            end
-        end
-    elseif parentof(x) isa EXPR
-        return _get_last_method(parentof(x), b.name, server)
-    end
-    return b
 end
 
 function _get_top_binding(s::Scope, name::String)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -156,8 +156,9 @@ isquoted(x::EXPR) = typof(x) === CSTParser.Quotenode && length(x) == 2 && kindof
 maybeget_quotedsymbol(x::EXPR) = isquoted(x) ? maybe_eventually_get_id(x[2]) : nothing
 is_loop_iterator(x::EXPR) = is_binary_call(x) && (kindof(x[2]) === CSTParser.Tokens.EQ || kindof(x[2]) === CSTParser.Tokens.IN || kindof(x[2]) === CSTParser.Tokens.ELEMENT_OF)
 
+function maybeget_listofnames(b) end
 function maybeget_listofnames(b::Binding)
-    if is_assignment(b.val) || is_loop_iterator(b.val)
+    if (is_assignment(b.val) || (is_loop_iterator(b.val) && b.val isa EXPR && parentof(b.val) isa EXPR && typof(b.val) === CSTParser.For))
         rhs = b.val[3]
         if (rhsval = maybeget_quotedsymbol(rhs)) !== nothing
             return [rhsval]

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -154,7 +154,7 @@ function maybe_eventually_get_id(x::EXPR)
 end
 isquoted(x::EXPR) = typof(x) === CSTParser.Quotenode && length(x) == 2 && kindof(x[1]) === CSTParser.Tokens.COLON
 maybeget_quotedsymbol(x::EXPR) = isquoted(x) ? maybe_eventually_get_id(x[2]) : nothing
-is_loop_iterator(x::EXPR) = typof(x) === BinaryOpCall && length(x) == 3 && (kindof(x[2]) === CSTParser.Tokens.EQ || kindof(x[2]) === CSTParser.Tokens.IN || kindof(x[2]) === CSTParser.Tokens.ELEMENT_OF)
+is_loop_iterator(x::EXPR) = is_binary_call(x) && (kindof(x[2]) === CSTParser.Tokens.EQ || kindof(x[2]) === CSTParser.Tokens.IN || kindof(x[2]) === CSTParser.Tokens.ELEMENT_OF)
 
 function maybeget_listofnames(b::Binding)
     if is_assignment(b.val) || is_loop_iterator(b.val)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -154,9 +154,10 @@ function maybe_eventually_get_id(x::EXPR)
 end
 isquoted(x::EXPR) = typof(x) === CSTParser.Quotenode && length(x) == 2 && kindof(x[1]) === CSTParser.Tokens.COLON
 maybeget_quotedsymbol(x::EXPR) = isquoted(x) ? maybe_eventually_get_id(x[2]) : nothing
+is_loop_iterator(x::EXPR) = typof(x) === BinaryOpCall && length(x) == 3 && (kindof(x[2]) === CSTParser.Tokens.EQ || kindof(x[2]) === CSTParser.Tokens.IN || kindof(x[2]) === CSTParser.Tokens.ELEMENT_OF)
 
 function maybeget_listofnames(b::Binding)
-    if is_assignment(b.val)
+    if is_assignment(b.val) || is_loop_iterator(b.val)
         rhs = b.val[3]
         if (rhsval = maybeget_quotedsymbol(rhs)) !== nothing
             return [rhsval]

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -143,7 +143,7 @@ function maybe_eventually_get_id(x::EXPR)
     return nothing
 end
 
-is_eventually_interpolated(x::EXPR) = is_invis_brackets(x) ? is_eventually_interpolated(x[2]) : CSTParser.isunarycall(x) && CSTParser.is_exor(x[1])
+is_eventually_interpolated(x::EXPR) = is_invis_brackets(x) ? is_eventually_interpolated(x[2]) : is_unary_call(x) && CSTParser.is_exor(x[1])
 isquoted(x::EXPR) = typof(x) === CSTParser.Quotenode && length(x) == 2 && kindof(x[1]) === CSTParser.Tokens.COLON
 maybeget_quotedsymbol(x::EXPR) = isquoted(x) ? maybe_eventually_get_id(x[2]) : nothing
 

--- a/src/references.jl
+++ b/src/references.jl
@@ -139,6 +139,8 @@ function resolve_ref(x::EXPR, m, state::State)::Bool
     return hasref(x)::Bool
 end
 
+rhs_of_getfield(x::EXPR) = is_getfield_w_quotenode(x) ? isquoted(x[3]) ? x[3][2] : x[3][1] : x
+lhs_of_getfield(x::EXPR) = rhs_of_getfield(x[1])
 
 """
     resolve_getfield(x::EXPR, parent::Union{EXPR,Scope,ModuleStore,Binding}, state::State)::Bool
@@ -150,17 +152,16 @@ a field matching `x`.
 """
 function resolve_getfield(x::EXPR, scope::Scope, state::State)::Bool
     hasref(x) && return true
-    resolved = false
+    resolved = resolve_ref(x[1], scope, state)
     if isidentifier(x[1])
-        resolved = resolve_ref(x[1], scope, state)
-        if resolved && typof(x[3]) === Quotenode && is_id_or_macroname(x[3][1])
-            resolved = resolve_getfield(x[3][1], refof(x[1]), state)
-        end
+        lhs = x[1]
     elseif is_getfield_w_quotenode(x[1])
-        resolved = resolve_ref(x[1], scope, state)
-        if resolved && typof(x[3]) === Quotenode && length(x[3]) > 0 && is_id_or_macroname(x[3][1])
-            resolved = resolve_getfield(x[3][1], refof(x[1][3][1]), state)
-        end
+        lhs = lhs_of_getfield(x)
+    else
+        return resolved
+    end
+    if resolved && (rhs = rhs_of_getfield(x)) !== nothing
+        resolved = resolve_getfield(rhs, refof(lhs), state)
     end
     return resolved
 end

--- a/src/references.jl
+++ b/src/references.jl
@@ -153,12 +153,12 @@ function resolve_getfield(x::EXPR, scope::Scope, state::State)::Bool
     resolved = false
     if isidentifier(x[1])
         resolved = resolve_ref(x[1], scope, state)
-        if resolved && typof(x[3]) === Quotenode && isidentifier(x[3][1])
+        if resolved && typof(x[3]) === Quotenode && is_id_or_macroname(x[3][1])
             resolved = resolve_getfield(x[3][1], refof(x[1]), state)
         end
     elseif is_getfield_w_quotenode(x[1])
         resolved = resolve_ref(x[1], scope, state)
-        if resolved && typof(x[3]) === Quotenode && length(x[3]) > 0 && isidentifier(x[3][1])
+        if resolved && typof(x[3]) === Quotenode && length(x[3]) > 0 && is_id_or_macroname(x[3][1])
             resolved = resolve_getfield(x[3][1], refof(x[1][3][1]), state)
         end
     end
@@ -208,6 +208,9 @@ function resolve_getfield(x::EXPR, m::SymbolServer.ModuleStore, state::State)::B
     resolved = false
     if isidentifier(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(CSTParser.str_value(x)), m, getsymbolserver(state.server)), state.server)) !== nothing
         setref!(x, val)
+        resolved = true
+    elseif is_macroname(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol("@", CSTParser.str_value(x[2])), m, getsymbolserver(state.server)), state.server)) !== nothing
+        setref!(x[2], val)
         resolved = true
     end
     return resolved

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -139,40 +139,7 @@ function find_return_statements(x::EXPR, last_stmt, rets)
     return rets, false
 end
 
-    
-# should only be called on Bindings to functions
-function last_method(func::Binding)
-    if func.next isa Binding && (func.next.type === CoreTypes.Function || (func.next.type === CoreTypes.DataType && func.type === CoreTypes.Function))
-        return func.next
-    else
-        return func
-    end
-end
-
-function prev_method(func::Binding)
-    if func.prev isa Binding
-        if func.prev.type === CoreTypes.Function
-            return func.prev
-        elseif func.prev.type === CoreTypes.DataType && func.prev.val isa EXPR && CSTParser.defines_struct(func.prev.val)
-            return func.prev
-        elseif (func.prev.val isa SymbolServer.FunctionStore || func.prev.val isa SymbolServer.DataTypeStore) && length(func.prev.val.methods) > 0
-            return func.prev.val, 1
-        end
-    elseif (func.prev isa SymbolServer.FunctionStore || func.prev isa SymbolServer.DataTypeStore) && length(func.prev.methods) > 0
-        return func.prev, 1
-    end
-    return nothing
-end
-
-function prev_method(func_iter::Tuple{T,Int}) where T <: Union{SymbolServer.FunctionStore,SymbolServer.DataTypeStore}
-    func = func_iter[1]
-    iter = func_iter[2]
-    if iter < length(func.methods) 
-        return func, iter + 1
-    else
-        return nothing
-    end
-end
+last_method(b::Binding, visited = Binding[]) = b.next isa Binding && b.next.type === CoreTypes.Function && !(b in visited) ? (push!(visited, b);last_method(b.next, visited)) : b
 
 function find_exported_names(x::EXPR)
     exported_vars = EXPR[]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -298,7 +298,7 @@ is_unary_call(x::EXPR) = typof(x) === CSTParser.UnaryOpCall && length(x) == 2
 is_binary_call(x::EXPR) = typof(x) === CSTParser.BinaryOpCall && length(x) == 3
 is_binary_call(x::EXPR, opkind) = is_binary_call(x) && kindof(x[2]) === opkind
 is_macro_call(x::EXPR) = typof(x) === CSTParser.MacroCall
-is_macroname(x::EXPR) = typof(x) === CSTParser.MacroName && length(x) == 2
+is_macroname(x::EXPR) = (typof(x) === CSTParser.MacroName && length(x) == 2) || (is_getfield_w_quotenode(x) && is_macroname(x[3][1]))
 is_id_or_macroname(x::EXPR) = isidentifier(x) || is_macroname(x)
 is_getfield(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == CSTParser.Tokens.DOT 
 is_getfield_w_quotenode(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == CSTParser.Tokens.DOT && typof(x[3]) === CSTParser.Quotenode && length(x[3]) > 0 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1042,5 +1042,14 @@ end
     StaticLint.scopepass(f)
 end
 
+let cst = parse_and_pass("""
+    using Base.@irrational
+    @irrational ase 0.45343 π
+    ase
+    """)
+    StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
+    @test isempty(StaticLint.collect_hints(cst, server))
+end
+
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -618,6 +618,28 @@ end
         StaticLint.check_call(cst[2], server)
         @test StaticLint.errorof(cst[2]) === nothing
     end
+    let cst = parse_and_pass("""
+        import Base: sin
+        \"\"\"
+        docs
+        \"\"\"
+        sin
+        sin(a,b) = 1
+        sin(1)
+        """)
+        # Checks that documented symbols are skipped
+        StaticLint.check_all(cst, StaticLint.LintOptions(), server)
+        @test isempty(StaticLint.collect_hints(cst, server))
+    end
+    let cst = parse_and_pass("""
+        import Base: sin
+        sin(a,b) = 1
+        sin(1)
+        """)
+        # Checks that documented symbols are skipped
+        StaticLint.check_all(cst, StaticLint.LintOptions(), server)
+        @test isempty(StaticLint.collect_hints(cst, server))
+    end
 end
 
 @testset "check_modulename" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1073,5 +1073,22 @@ let cst = parse_and_pass("""
     @test isempty(StaticLint.collect_hints(cst, server))
 end
 
+@testset "quoted getfield" begin
+let cst = parse_and_pass("""
+    Base.:sin
+    """)
+    StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
+    @test isempty(StaticLint.collect_hints(cst[1], server))
+end
+
+let cst = parse_and_pass("""
+    sin(1,1)
+    Base.sin(1,1)
+    Base.:sin(1,1)
+    """)
+    StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
+    @test errorof(cst[1]) === errorof(cst[2]) === errorof(cst[3])
+end
+end
 end
 


### PR DESCRIPTION
Handles the case where an expression passed to `@eval` introduces a binding. Lifts the binding to the top-level scope. 