### PR TITLE
Fixes

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, OPERATOR, isidentifier, Call, WhereOpCall, Import, Using, Export, TopLevel, ModuleH, BareModule, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment
+using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, OPERATOR, isidentifier, Call, WhereOpCall, Import, Using, Export, TopLevel, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, OPERATOR, isidentifier, Call, UnaryOpCall, BinaryOpCall, WhereOpCall, Import, Using, Export, TopLevel, ModuleH, BareModule, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment
+using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, OPERATOR, isidentifier, Call, UnaryOpCall, WhereOpCall, Import, Using, Export, TopLevel, ModuleH, BareModule, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience
@@ -99,7 +99,7 @@ Iterates across the child nodes of an EXPR in execution order (rather than
 storage order) calling `state` on each node.
 """
 function traverse(x::EXPR, state)
-    if typof(x) === CSTParser.BinaryOpCall && (CSTParser.is_assignment(x) && !CSTParser.is_func_call(x[1]) || typof(x[2]) === CSTParser.Tokens.DECLARATION) && !(CSTParser.is_assignment(x) && typof(x[1]) === CSTParser.Curly)
+    if is_binary_call(x) && (CSTParser.is_assignment(x) && !CSTParser.is_func_call(x[1]) || typof(x[2]) === CSTParser.Tokens.DECLARATION) && !(CSTParser.is_assignment(x) && typof(x[1]) === CSTParser.Curly)
         state(x[3])
         state(x[2])
         state(x[1])

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, isidentifier, Call, Import, Using, Export, TopLevel, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator
+using CSTParser: EXPR, IDENTIFIER, KEYWORD, isidentifier, Call, Import, Using, Export, TopLevel, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, KEYWORD, isidentifier, Import, Using, Export, TopLevel, Quote, Quotenode, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation
+using CSTParser: EXPR, isidentifier, Import, Using, Export, Quote, Quotenode, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation, iskw, defines_function
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, IDENTIFIER, KEYWORD, isidentifier, Call, Import, Using, Export, TopLevel, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation
+using CSTParser: EXPR, IDENTIFIER, KEYWORD, isidentifier, Import, Using, Export, TopLevel, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience
@@ -140,7 +140,7 @@ If this is successful it traverses the code associated with the loaded file.
 
 """
 function followinclude(x, state::State)
-    if typof(x) === Call && length(x) > 0 && typof(x[1]) === IDENTIFIER && valof(x[1]) == "include"
+    if is_call(x) && length(x) > 0 && typof(x[1]) === IDENTIFIER && valof(x[1]) == "include"
         path = get_path(x, state)
         if isempty(path)
         elseif hasfile(state.server, path)

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, isidentifier, Import, Using, Export, Quote, Quotenode, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation, iskw, defines_function
+using CSTParser: EXPR, isidentifier, Import, Using, Export, Quote, Quotenode, x_Str, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation, iskw, defines_function
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, IDENTIFIER, KEYWORD, isidentifier, Import, Using, Export, TopLevel, Quote, Quotenode, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation
+using CSTParser: EXPR, KEYWORD, isidentifier, Import, Using, Export, TopLevel, Quote, Quotenode, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience
@@ -140,7 +140,7 @@ If this is successful it traverses the code associated with the loaded file.
 
 """
 function followinclude(x, state::State)
-    if is_call(x) && length(x) > 0 && typof(x[1]) === IDENTIFIER && valof(x[1]) == "include"
+    if is_call(x) && length(x) > 0 && isidentifier(x[1]) && valofid(x[1]) == "include"
         path = get_path(x, state)
         if isempty(path)
         elseif hasfile(state.server, path)

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, OPERATOR, isidentifier, Call, WhereOpCall, Import, Using, Export, TopLevel, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment
+using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, OPERATOR, isidentifier, Call, Import, Using, Export, TopLevel, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience
@@ -103,7 +103,7 @@ function traverse(x::EXPR, state)
         state(x[3])
         state(x[2])
         state(x[1])
-    elseif typof(x) === CSTParser.WhereOpCall
+    elseif is_where(x)
         @inbounds for i = 3:length(x)
             state(x[i])
         end

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, OPERATOR, isidentifier, Call, UnaryOpCall, WhereOpCall, Import, Using, Export, TopLevel, ModuleH, BareModule, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment
+using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, OPERATOR, isidentifier, Call, WhereOpCall, Import, Using, Export, TopLevel, ModuleH, BareModule, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, OPERATOR, isidentifier, Call, Import, Using, Export, TopLevel, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment
+using CSTParser: EXPR, PUNCTUATION, IDENTIFIER, KEYWORD, isidentifier, Call, Import, Using, Export, TopLevel, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -3,7 +3,7 @@ module StaticLint
 include("exception_types.jl")
 
 using SymbolServer, CSTParser
-using CSTParser: EXPR, IDENTIFIER, KEYWORD, isidentifier, Import, Using, Export, TopLevel, Quote, Quotenode, MacroName, MacroCall, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation
+using CSTParser: EXPR, IDENTIFIER, KEYWORD, isidentifier, Import, Using, Export, TopLevel, Quote, Quotenode, Macro, x_Str, FileH, Parameters, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -99,7 +99,7 @@ Iterates across the child nodes of an EXPR in execution order (rather than
 storage order) calling `state` on each node.
 """
 function traverse(x::EXPR, state)
-    if is_binary_call(x) && (CSTParser.is_assignment(x) && !CSTParser.is_func_call(x[1]) || typof(x[2]) === CSTParser.Tokens.DECLARATION) && !(CSTParser.is_assignment(x) && typof(x[1]) === CSTParser.Curly)
+    if is_binary_call(x) && (CSTParser.is_assignment(x) && !CSTParser.is_func_call(x[1]) || typof(x[2]) === CSTParser.Tokens.DECLARATION) && !(CSTParser.is_assignment(x) && is_curly(x[1]))
         state(x[3])
         state(x[2])
         state(x[1])

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -62,34 +62,34 @@ function mark_bindings!(x::EXPR, state)
         end
     elseif is_where(x)
         for i = 3:length(x)
-            typof(x[i]) === PUNCTUATION && continue
+            ispunctuation(x[i]) && continue
             mark_binding!(x[i])
         end
     elseif typof(x) === CSTParser.For
         markiterbinding!(x[2])
     elseif typof(x) === CSTParser.Generator
         for i = 3:length(x)
-            typof(x[i]) === PUNCTUATION && continue
+            ispunctuation(x[i]) && continue
             markiterbinding!(x[i])
         end
     elseif typof(x) === CSTParser.Filter
         for i = 1:length(x) - 2
-            typof(x[i]) === PUNCTUATION && continue
+            ispunctuation(x[i]) && continue
             markiterbinding!(x[i])
         end
     elseif typof(x) === CSTParser.Flatten && length(x) === 1 && length(x[1]) >= 3 && length(x[1][1]) >= 3
         for i = 3:length(x[1][1])
-            typof(x[1][1][i]) === PUNCTUATION && continue
+            ispunctuation(x[1][1][i]) && continue
             markiterbinding!(x[1][1][i])
         end
         for i = 3:length(x[1])
-            typof(x[1][i]) === PUNCTUATION && continue
+            ispunctuation(x[1][i]) && continue
             markiterbinding!(x[1][i])
         end
     elseif typof(x) === CSTParser.Do
         if typof(x[3]) === CSTParser.TupleH
             for i in 1:length(x[3])
-                typof(x[3][i]) === PUNCTUATION && continue
+                ispunctuation(x[3][i])ispunctuation && continue
                 mark_binding!(x[3][i])
             end
         end
@@ -144,7 +144,7 @@ function mark_binding!(x::EXPR, val = x)
         mark_binding!(x[1], x)
     elseif typof(x) === CSTParser.TupleH || typof(x) === Parameters
         for arg in x
-            typof(arg) === PUNCTUATION && continue
+            ispunctuation(arg) && continue
             mark_binding!(arg, val)
         end
     elseif typof(x) === CSTParser.InvisBrackets
@@ -163,7 +163,7 @@ function mark_parameters(sig::EXPR)
     signame = CSTParser.rem_where_subtype(sig)
     if typof(signame) === CSTParser.Curly
         for i = 3:length(signame) - 1
-            typof(signame[i]) === PUNCTUATION && continue
+            ispunctuation(signame[i]) && continue
             mark_binding!(signame[i])
         end
     end
@@ -176,7 +176,7 @@ function markiterbinding!(iter::EXPR)
         mark_binding!(iter[1], iter)
     elseif typof(iter) === CSTParser.Block
         for i = 1:length(iter)
-            typof(iter[i]) === PUNCTUATION && continue
+            ispunctuation(iter[i]) && continue
             markiterbinding!(iter[i])
         end
     end
@@ -193,17 +193,17 @@ function mark_sig_args!(x::EXPR)
             if typof(a) === Parameters
                 for j = 1:length(a)
                     aa = a[j]
-                    if !(typof(aa) === PUNCTUATION)
+                    if !ispunctuation(aa)
                         mark_binding!(aa)
                     end
                 end
-            elseif !(typof(a) === PUNCTUATION)
+            elseif !ispunctuation(a)
                 mark_binding!(a)
             end
         end
     elseif is_where(x)
         for i in 3:length(x)
-            if !(typof(x[i]) === PUNCTUATION)
+            if !ispunctuation(x[i])
                 mark_binding!(x[i])
             end
         end

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -60,7 +60,7 @@ function mark_bindings!(x::EXPR, state)
         elseif kindof(x[2]) === CSTParser.Tokens.ANON_FUNC
             mark_binding!(x[1], x)
         end
-    elseif typof(x) === WhereOpCall
+    elseif is_where(x)
         for i = 3:length(x)
             typof(x[i]) === PUNCTUATION && continue
             mark_binding!(x[i])
@@ -201,7 +201,7 @@ function mark_sig_args!(x::EXPR)
                 mark_binding!(a)
             end
         end
-    elseif typof(x) === WhereOpCall
+    elseif is_where(x)
         for i in 3:length(x)
             if !(typof(x[i]) === PUNCTUATION)
                 mark_binding!(x[i])
@@ -238,7 +238,7 @@ function _in_func_def(x::EXPR)
     # check 1st arg contains a call (or op call)
     ex = x[1]
     while true
-        if typof(ex) === WhereOpCall || is_declaration(ex)
+        if is_where(ex) || is_declaration(ex)
             ex = ex[1]
         elseif typof(ex) === Call || (is_binary_call(ex) && kindof(ex[2]) !== CSTParser.Tokens.DOT) || is_unary_call(ex)
             break
@@ -251,7 +251,7 @@ function _in_func_def(x::EXPR)
     while true
         if !(parentof(ex) isa EXPR)
             return false
-        elseif typof(parentof(ex)) === WhereOpCall || typof(parentof(ex)) === CSTParser.InvisBrackets
+        elseif is_where(parentof(ex)) || typof(parentof(ex)) === CSTParser.InvisBrackets
             ex = parentof(ex)
         elseif typof(parentof(ex)) === FunctionDef || CSTParser.is_assignment(parentof(ex))
             return true

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -52,7 +52,7 @@ function mark_bindings!(x::EXPR, state)
                 if isidentifier(name)
                     setref!(name, bindingof(x))
                 end
-            elseif typof(x[1]) === CSTParser.Curly
+            elseif is_curly(x[1])
                 mark_typealias_bindings!(x)
             else
                 mark_binding!(x[1], x)
@@ -161,7 +161,7 @@ end
 
 function mark_parameters(sig::EXPR)
     signame = CSTParser.rem_where_subtype(sig)
-    if typof(signame) === CSTParser.Curly
+    if is_curly(signame)
         for i = 3:length(signame) - 1
             ispunctuation(signame[i]) && continue
             mark_binding!(signame[i])

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -149,7 +149,7 @@ function mark_binding!(x::EXPR, val = x)
         end
     elseif typof(x) === CSTParser.InvisBrackets
         mark_binding!(CSTParser.rem_invis(x), val)
-    elseif !(typof(x) == UnaryOpCall && kindof(x[1]) === CSTParser.Tokens.DECLARATION)
+    elseif !(is_unary_call(x) && kindof(x[1]) === CSTParser.Tokens.DECLARATION)
         if !hasmeta(x)
             x.meta = Meta()
         end
@@ -215,7 +215,7 @@ function mark_sig_args!(x::EXPR)
             mark_binding!(x[1])
             mark_binding!(x[3])
         end
-    elseif typof(x) == UnaryOpCall && typof(x[2]) == CSTParser.InvisBrackets
+    elseif is_unary_call(x) && typof(x[2]) == CSTParser.InvisBrackets
         mark_binding!(x[2][2])
     end
 end
@@ -240,7 +240,7 @@ function _in_func_def(x::EXPR)
     while true
         if typof(ex) === WhereOpCall || is_declaration(ex)
             ex = ex[1]
-        elseif typof(ex) === Call || (is_binary_call(ex) && kindof(ex[2]) !== CSTParser.Tokens.DOT) || typof(ex) == CSTParser.UnaryOpCall
+        elseif typof(ex) === Call || (is_binary_call(ex) && kindof(ex[2]) !== CSTParser.Tokens.DOT) || is_unary_call(ex)
             break
         else
             return false

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -208,6 +208,8 @@ function mark_sig_args!(x::EXPR)
             end
         end
         mark_sig_args!(x[1])
+    elseif is_invis_brackets(x)
+        mark_sig_args!(CSTParser.rem_invis(x))
     elseif is_binary_call(x)
         if kindof(x[2]) == CSTParser.Tokens.DECLARATION
             mark_sig_args!(x[1])

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -270,7 +270,7 @@ function add_binding(x, state, scope = state.scope)
             name = valof(bindingof(x).name)
         elseif typof(bindingof(x).name) === CSTParser.NONSTDIDENTIFIER
             name = valof(bindingof(x).name[2])
-        elseif CSTParser.typof(bindingof(x).name) === CSTParser.MacroName
+        elseif is_macroname(bindingof(x).name)
             name = string(Expr(bindingof(x).name))
         elseif isoperator(bindingof(x).name)
             name = string(Expr(bindingof(x).name))

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -142,7 +142,7 @@ end
 function mark_binding!(x::EXPR, val = x)
     if is_kwarg(x) || (is_declaration(x) && is_tuple(x[1]))
         mark_binding!(x[1], x)
-    elseif is_tuple(x) || typof(x) === Parameters
+    elseif is_tuple(x) || is_parameters(x)
         for arg in x
             ispunctuation(arg) && continue
             mark_binding!(arg, val)
@@ -190,7 +190,7 @@ function mark_sig_args!(x::EXPR)
         end
         for i = 2:length(x) - 1
             a = x[i]
-            if typof(a) === Parameters
+            if is_parameters(a)
                 for j = 1:length(a)
                     aa = a[j]
                     if !ispunctuation(aa)
@@ -321,7 +321,7 @@ function add_binding(x, state, scope = state.scope)
         end
         infer_type(bindingof(x), scope, state)
     elseif bindingof(x) isa SymbolServer.SymStore
-        scope.names[valof(x)] = bindingof(x)
+        scope.names[valofid(x)] = bindingof(x)
     end
 end
 

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -184,7 +184,7 @@ function markiterbinding!(iter::EXPR)
 end
 
 function mark_sig_args!(x::EXPR)
-    if typof(x) === Call || typof(x) === CSTParser.TupleH
+    if is_call(x) || typof(x) === CSTParser.TupleH
         if typof(x[1]) === CSTParser.InvisBrackets && is_declaration(x[1][2])
             mark_binding!(x[1][2])
         end
@@ -240,7 +240,7 @@ function _in_func_def(x::EXPR)
     while true
         if is_where(ex) || is_declaration(ex)
             ex = ex[1]
-        elseif typof(ex) === Call || (is_binary_call(ex) && kindof(ex[2]) !== CSTParser.Tokens.DOT) || is_unary_call(ex)
+        elseif is_call(ex) || (is_binary_call(ex) && kindof(ex[2]) !== CSTParser.Tokens.DOT) || is_unary_call(ex)
             break
         else
             return false

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -272,7 +272,7 @@ function add_binding(x, state, scope = state.scope)
             name = valof(bindingof(x).name[2])
         elseif CSTParser.typof(bindingof(x).name) === CSTParser.MacroName
             name = string(Expr(bindingof(x).name))
-        elseif CSTParser.typof(bindingof(x).name) === CSTParser.OPERATOR
+        elseif isoperator(bindingof(x).name)
             name = string(Expr(bindingof(x).name))
         else
             return

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -8,7 +8,7 @@ function resolve_import(x, state::State)
         bindings = []
         while i <= n
             arg = x[i]
-            if isidentifier(arg) || typof(arg) === CSTParser.MacroName
+            if is_id_or_macroname(arg)
                 if refof(arg) !== nothing
                     par = refof(arg)
                 else
@@ -51,7 +51,7 @@ function resolve_import(x, state::State)
 end
 
 function _mark_import_arg(arg, par, state, u)
-    if par !== nothing && (typof(arg) === IDENTIFIER || typof(arg) === MacroName)
+    if par !== nothing && is_id_or_macroname(arg)
         if par isa Binding # mark reference to binding
             push!(par.refs, arg)
         end

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -77,13 +77,13 @@ function _mark_import_arg(arg, par, state, u)
             else
                 state.scope.modules = Dict(Symbol(valof(arg)) => par.val)
             end
-        elseif u && par isa Binding && par.val isa EXPR && (typof(par.val) === CSTParser.ModuleH || typof(par.val) === CSTParser.BareModule)
+        elseif u && par isa Binding && par.val isa EXPR && CSTParser.defines_module(par.val)
             if state.scope.modules isa Dict
                 state.scope.modules[Symbol(valof(arg))] = scopeof(par.val)
             else
                 state.scope.modules = Dict(Symbol(valof(arg)) => scopeof(par.val))
             end
-        elseif u && par isa Binding && par.val isa Binding && par.val.val isa EXPR && (typof(par.val.val) === CSTParser.ModuleH || typof(par.val.val) === CSTParser.BareModule)
+        elseif u && par isa Binding && par.val isa Binding && par.val.val isa EXPR && CSTParser.defines_module(par.val.val)
             if state.scope.modules isa Dict
                 state.scope.modules[Symbol(valof(arg))] = scopeof(par.val.val)
             else

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -14,7 +14,7 @@ function resolve_import(x, state::State)
                 else
                     par = _get_field(par, arg, state)
                 end
-            elseif typof(arg) === PUNCTUATION && kindof(arg) == CSTParser.Tokens.COMMA
+            elseif ispunctuation(arg) && kindof(arg) == CSTParser.Tokens.COMMA
                 # end of chain, make available
                 if i > 2
                     _mark_import_arg(x[i - 1], par, state, u)
@@ -25,7 +25,7 @@ function resolve_import(x, state::State)
                 if par !== nothing && i > 2 && isidentifier(x[i - 1]) && refof(x[i - 1]) === nothing
                     setref!(x[i - 1], par)
                 end
-            elseif typof(arg) === PUNCTUATION && kindof(arg) == CSTParser.Tokens.DOT
+            elseif ispunctuation(arg) && kindof(arg) == CSTParser.Tokens.DOT
                 # dot between identifiers
                 if par !== nothing && i > 2 && isidentifier(x[i - 1]) && refof(x[i - 1]) === nothing
                     setref!(x[i - 1], par)

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -20,7 +20,7 @@ function resolve_import(x, state::State)
                     _mark_import_arg(x[i - 1], par, state, u)
                 end
                 par = root
-            elseif typof(arg) === OPERATOR && kindof(arg) == CSTParser.Tokens.COLON
+            elseif isoperator(arg) && kindof(arg) == CSTParser.Tokens.COLON
                 root = par
                 if par !== nothing && i > 2 && isidentifier(x[i - 1]) && refof(x[i - 1]) === nothing
                     setref!(x[i - 1], par)
@@ -30,7 +30,7 @@ function resolve_import(x, state::State)
                 if par !== nothing && i > 2 && isidentifier(x[i - 1]) && refof(x[i - 1]) === nothing
                     setref!(x[i - 1], par)
                 end
-            elseif typof(arg) === OPERATOR && kindof(arg) == CSTParser.Tokens.DOT
+            elseif isoperator(arg) && kindof(arg) == CSTParser.Tokens.DOT
                 # dot prexceding identifiser
                 if par == root == getsymbolserver(state.server)
                     par = state.scope

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -95,7 +95,7 @@ function func_nargs(x::EXPR)
                 arg = arg[2]
             end
         end
-        if typof(arg) === CSTParser.PUNCTUATION
+        if ispunctuation(arg)
             # skip
         elseif typof(arg) === CSTParser.Parameters
             for j = 1:length(arg)
@@ -152,7 +152,7 @@ function call_nargs(x::EXPR)
     if length(x) > 0
         for i = 2:length(x)
             arg = x[i]
-            if typof(arg) === CSTParser.PUNCTUATION
+            if ispunctuation(arg)
                 # skip
             elseif typof(x[i]) === CSTParser.Parameters
                 for j = 1:length(x[i])

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -608,7 +608,7 @@ end
 isunionfaketype(t::SymbolServer.FakeTypeName) = t.name.name === :Union && t.name.parent isa SymbolServer.VarRef && t.name.parent.name === :Core
 
 function check_typeparams(x::EXPR)
-    if typof(x) === CSTParser.WhereOpCall
+    if is_where(x)
         for i = 3:length(x)
             if hasbinding(x[i])
                 if !(bindingof(x[i]).refs isa Vector) 

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -90,14 +90,14 @@ function func_nargs(x::EXPR)
     for i = 2:length(sig)
         arg = sig[i]
         if is_macro_call(arg) && length(arg) > 1 &&
-            is_macroname(arg[1]) && valof(arg[1][2]) == "nospecialize"
+            is_macroname(arg[1]) && valofid(arg[1][2]) == "nospecialize"
             if length(arg) == 2
                 arg = arg[2]
             end
         end
         if ispunctuation(arg)
             # skip
-        elseif typof(arg) === CSTParser.Parameters
+        elseif is_parameters(arg)
             for j = 1:length(arg)
                 arg1 = arg[j]
                 if is_kwarg(arg1)
@@ -154,7 +154,7 @@ function call_nargs(x::EXPR)
             arg = x[i]
             if ispunctuation(arg)
                 # skip
-            elseif typof(x[i]) === CSTParser.Parameters
+            elseif is_parameters(x[i])
                 for j = 1:length(x[i])
                     arg = x[i][j]
                     if is_kwarg(arg)

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -642,7 +642,7 @@ end
 
 function fname_is_noteq(x)
     if x isa EXPR
-        if typof(x) === CSTParser.OPERATOR && kindof(x) === CSTParser.Tokens.NOT_EQ
+        if isoperator(x) && kindof(x) === CSTParser.Tokens.NOT_EQ
             return true
         elseif is_getfield_w_quotenode(x) && length(x[3]) == 2 && CSTParser.is_colon(x[3][1])
 

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -114,8 +114,8 @@ function func_nargs(x::EXPR)
             end
         elseif (is_unary_call(arg) && kindof(arg[2]) === CSTParser.Tokens.DDDOT) ||
             (is_declaration(arg) &&
-            ((typof(arg[3]) === CSTParser.IDENTIFIER && valof(arg[3]) == "Vararg") ||
-            (typof(arg[3]) === CSTParser.Curly && typof(arg[3][1]) === CSTParser.IDENTIFIER && valof(arg[3][1]) == "Vararg")))
+            ((isidentifier(arg[3]) && valofid(arg[3]) == "Vararg") ||
+            (typof(arg[3]) === CSTParser.Curly && isidentifier(arg[3][1]) && valofid(arg[3][1]) == "Vararg")))
             maxargs = typemax(Int)
         else
             minargs += 1
@@ -492,7 +492,7 @@ function collect_hints(x::EXPR, server, missingrefs = :all, isquoted = false, er
         push!(errs, (pos, x))
     elseif !isquoted
         if missingrefs != :none && CSTParser.isidentifier(x) && !hasref(x) && 
-            !(valof(x) == "var" && parentof(x) isa EXPR && typof(parentof(x)) === CSTParser.NONSTDIDENTIFIER) &&
+            !(valof(x) == "var" && parentof(x) isa EXPR && isnonstdid(parentof(x))) &&
             !((valof(x) == "stdcall" || valof(x) == "cdecl" || valof(x) == "fastcall" || valof(x) == "thiscall" || valof(x) == "llvmcall") && is_in_fexpr(x, x->is_call(x) && isidentifier(x[1]) && valof(x[1]) == "ccall"))
             push!(errs, (pos, x))
         elseif haserror(x) && errorof(x) isa StaticLint.LintCodes

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -100,13 +100,13 @@ function func_nargs(x::EXPR)
         elseif typof(arg) === CSTParser.Parameters
             for j = 1:length(arg)
                 arg1 = arg[j]
-                if typof(arg1) === CSTParser.Kw
+                if is_kwarg(arg1)
                     push!(kws, Symbol(CSTParser.str_value(CSTParser.get_arg_name(arg1[1]))))
                 elseif is_binary_call(arg1) && kindof(arg1[2]) === CSTParser.Tokens.DDDOT
                     kwsplat = true
                 end
             end
-        elseif typof(arg) === CSTParser.Kw
+        elseif is_kwarg(arg)
             if is_unary_call(arg[1]) && kindof(arg[1][2]) === CSTParser.Tokens.DDDOT
                 maxargs = typemax(Int)
             else
@@ -157,11 +157,11 @@ function call_nargs(x::EXPR)
             elseif typof(x[i]) === CSTParser.Parameters
                 for j = 1:length(x[i])
                     arg = x[i][j]
-                    if typof(arg) === CSTParser.Kw
+                    if is_kwarg(arg)
                         push!(kws, Symbol(CSTParser.str_value(CSTParser.get_arg_name(arg[1]))))
                     end
                 end
-            elseif typof(arg) === CSTParser.Kw
+            elseif is_kwarg(arg)
                 push!(kws, Symbol(CSTParser.str_value(CSTParser.get_arg_name(arg[1]))))
             elseif is_unary_call(arg) && kindof(arg[2]) === CSTParser.Tokens.DDDOT
                 maxargs = typemax(Int)
@@ -345,7 +345,7 @@ end
 
 function check_if_conds(x::EXPR)
     if typof(x) === CSTParser.If && length(x) > 2 
-        cond = typof(first(x)) == CSTParser.KEYWORD ? x[2] : x[1]
+        cond = iskw(first(x)) ? x[2] : x[1]
         if typof(cond) === CSTParser.LITERAL && (kindof(cond) === CSTParser.Tokens.TRUE || kindof(cond) === CSTParser.Tokens.FALSE)
             seterror!(cond, ConstIfCondition)
         elseif is_binary_call(cond, CSTParser.Tokens.EQ)
@@ -420,7 +420,7 @@ function check_farg_unused(x::EXPR)
             for i = 2:length(sig)
                 if hasbinding(sig[i])
                     arg = sig[i]
-                elseif typof(sig[i]) === CSTParser.Kw && hasbinding(sig[i][1])
+                elseif is_kwarg(sig[i]) && hasbinding(sig[i][1])
                     arg = sig[i][1]
                 else
                     continue

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -107,12 +107,12 @@ function func_nargs(x::EXPR)
                 end
             end
         elseif typof(arg) === CSTParser.Kw
-            if typof(arg[1]) === UnaryOpCall && kindof(arg[1][2]) === CSTParser.Tokens.DDDOT
+            if is_unary_call(arg[1]) && kindof(arg[1][2]) === CSTParser.Tokens.DDDOT
                 maxargs = typemax(Int)
             else
                 maxargs !== typemax(Int) && (maxargs += 1)
             end
-        elseif (typof(arg) === UnaryOpCall && kindof(arg[2]) === CSTParser.Tokens.DDDOT) ||
+        elseif (is_unary_call(arg) && kindof(arg[2]) === CSTParser.Tokens.DDDOT) ||
             (is_declaration(arg) &&
             ((typof(arg[3]) === CSTParser.IDENTIFIER && valof(arg[3]) == "Vararg") ||
             (typof(arg[3]) === CSTParser.Curly && typof(arg[3][1]) === CSTParser.IDENTIFIER && valof(arg[3][1]) == "Vararg")))
@@ -163,7 +163,7 @@ function call_nargs(x::EXPR)
                 end
             elseif typof(arg) === CSTParser.Kw
                 push!(kws, Symbol(CSTParser.str_value(CSTParser.get_arg_name(arg[1]))))
-            elseif typof(arg) === CSTParser.UnaryOpCall && kindof(arg[2]) === CSTParser.Tokens.DDDOT
+            elseif is_unary_call(arg) && kindof(arg[2]) === CSTParser.Tokens.DDDOT
                 maxargs = typemax(Int)
             else
                 minargs += 1
@@ -656,7 +656,7 @@ end
 function refers_to_nonimported_type(arg::EXPR)
     if hasref(arg) && refof(arg) isa Binding
         return true
-    elseif typof(arg) === CSTParser.UnaryOpCall && length(arg) == 2 && (kindof(arg[1]) === CSTParser.Tokens.DECLARATION || kindof(arg[1]) === CSTParser.Tokens.ISSUBTYPE)
+    elseif is_unary_call(arg) && (kindof(arg[1]) === CSTParser.Tokens.DECLARATION || kindof(arg[1]) === CSTParser.Tokens.ISSUBTYPE)
         return refers_to_nonimported_type(arg[2])
     elseif is_declaration(arg)
         return refers_to_nonimported_type(arg[3])

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -71,7 +71,7 @@ end
 # Call
 function struct_nargs(x::EXPR)
     # struct defs wrapped in macros are likely to have some arbirtary additional constructors, so lets allow anything
-    parentof(x) isa EXPR && typof(parentof(x)) === CSTParser.MacroCall && return 0, typemax(Int), Symbol[], true 
+    parentof(x) isa EXPR && is_macro_call(parentof(x)) && return 0, typemax(Int), Symbol[], true 
     minargs, maxargs, kws, kwsplat = 0, 0, Symbol[], false
     args = typof(x) === CSTParser.Mutable ? x[4] : x[3]
     length(args) == 0 && return 0, typemax(Int), kws, kwsplat
@@ -89,8 +89,8 @@ function func_nargs(x::EXPR)
     sig = CSTParser.rem_where_decl(CSTParser.get_sig(x))
     for i = 2:length(sig)
         arg = sig[i]
-        if typof(arg) === CSTParser.MacroCall && length(arg) > 1 &&
-            _expr_assert(arg[1], MacroName, 2) && valof(arg[1][2]) == "nospecialize"
+        if is_macro_call(arg) && length(arg) > 1 &&
+            is_macroname(arg[1]) && valof(arg[1][2]) == "nospecialize"
             if length(arg) == 2
                 arg = arg[2]
             end

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -56,7 +56,7 @@ function _typeof(x, state)
     if x isa EXPR
         if typof(x) in (CSTParser.Abstract, CSTParser.Primitive, CSTParser.Struct, CSTParser.Mutable)
             return CoreTypes.DataType
-        elseif typof(x) in (CSTParser.ModuleH, CSTParser.BareModule)
+        elseif CSTParser.defines_module(x)
             return CoreTypes.Module
         elseif CSTParser.defines_function(x)
             return CoreTypes.Function
@@ -409,10 +409,9 @@ function check_datatype_decl(x::EXPR, server)
 end
 
 function check_modulename(x::EXPR)
-    if (typof(x) === CSTParser.ModuleH || typof(x) === CSTParser.BareModule) && # x is a module
+    if CSTParser.defines_module(x) && # x is a module
         scopeof(x) isa Scope && parentof(scopeof(x)) isa Scope && # it has a scope and a parent scope
-        (typof(parentof(scopeof(x)).expr) === CSTParser.ModuleH || 
-        typof(parentof(scopeof(x)).expr) === CSTParser.BareModule) && # the parent scope is a module
+        CSTParser.defines_module(parentof(scopeof(x)).expr) && # the parent scope is a module
         valof(CSTParser.get_name(x)) == valof(CSTParser.get_name(parentof(scopeof(x)).expr)) # their names match
         seterror!(CSTParser.get_name(x), InvalidModuleName)
     end

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -376,6 +376,8 @@ end
 function is_never_datatype(b::Binding, server)
     if b.val isa Binding
         return is_never_datatype(b.val, server)
+    elseif b.val isa SymbolServer.FunctionStore
+        return is_never_datatype(b.val, server)
     elseif b.type == CoreTypes.DataType
         return false
     elseif b.type == CoreTypes.Function && b.prev !== nothing

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -22,7 +22,7 @@ function handle_macro(x::EXPR, state)
             end
         elseif _points_to_Base_macro(x[1], :enum, state)
             for i = 2:length(x)
-                if !(typof(x[i]) === PUNCTUATION)
+                if !ispunctuation(x[i])
                     if bindingof(x[i]) !== nothing
                         break
                     end
@@ -45,7 +45,7 @@ function handle_macro(x::EXPR, state)
             end
         elseif length(x[1]) == 2 && isidentifier(x[1][2]) && valof(x[1][2]) == "nospecialize"
             for i = 2:length(x)
-                if !(typof(x[i]) === PUNCTUATION)
+                if !ispunctuation(x[i])
                     if bindingof(x[i]) !== nothing
                         break
                     end
@@ -64,7 +64,7 @@ function handle_macro(x::EXPR, state)
         elseif _points_to_arbitrary_macro(x[1], :JuMP, :variable, state)
             if length(x) < 3
                 return
-            elseif length(x) >= 5 && typof(x[2]) === PUNCTUATION
+            elseif length(x) >= 5 && ispunctuation(x[2])
                 _mark_JuMP_binding(x[5])
             else
                 _mark_JuMP_binding(x[3])
@@ -72,7 +72,7 @@ function handle_macro(x::EXPR, state)
         elseif (_points_to_arbitrary_macro(x[1], :JuMP, :expression, state) || 
             _points_to_arbitrary_macro(x[1], :JuMP, :NLexpression, state) ||
             _points_to_arbitrary_macro(x[1], :JuMP, :constraint, state) || _points_to_arbitrary_macro(x[1], :JuMP, :NLconstraint, state)) && length(x) > 1
-            if typof(x[2]) === PUNCTUATION 
+            if ispunctuation(x[2])
                 if length(x) == 8
                     _mark_JuMP_binding(x[5])
                 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,7 +1,7 @@
 function handle_macro(@nospecialize(x), state) end
 function handle_macro(x::EXPR, state)
-    typof(x) !== MacroCall && return
-    if typof(x[1]) === MacroName
+    !is_macro_call(x) && return
+    if is_macroname(x[1])
         state(x[1])
         if _points_to_Base_macro(x[1], :deprecate, state) && length(x) == 3
             if bindingof(x[2]) !== nothing

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -96,10 +96,10 @@ function _rem_ref(x::EXPR)
 end
 
 function _mark_JuMP_binding(arg)
-    if CSTParser.isidentifier(arg) || typof(arg) === CSTParser.Ref
+    if isidentifier(arg) || typof(arg) === CSTParser.Ref
         mark_binding!(_rem_ref(arg))
     elseif is_binary_call(arg, CSTParser.Tokens.EQEQ) || is_binary_call(arg, CSTParser.Tokens.LESS_EQ)  || is_binary_call(arg, CSTParser.Tokens.GREATER_EQ)
-        if CSTParser.isidentifier(arg[1]) || typof(arg[1]) === CSTParser.Ref
+        if isidentifier(arg[1]) || typof(arg[1]) === CSTParser.Ref
             mark_binding!(_rem_ref(arg[1]))
         else
             mark_binding!(_rem_ref(arg[3]))

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -36,14 +36,14 @@ function handle_macro(x::EXPR, state)
                 end
             end
         elseif _points_to_Base_macro(x[1], :goto, state)
-            if length(x) == 2 && typof(x[2]) === CSTParser.IDENTIFIER
+            if length(x) == 2 && isidentifier(x[2])
                 setref!(x[2], Binding(noname, nothing, nothing, EXPR[], nothing, nothing))
             end
         elseif _points_to_Base_macro(x[1], :label, state)
-            if length(x) == 2 && typof(x[2]) === CSTParser.IDENTIFIER
+            if length(x) == 2 && isidentifier(x[2])
                 mark_binding!(x[2])
             end
-        elseif length(x[1]) == 2 && isidentifier(x[1][2]) && valof(x[1][2]) == "nospecialize"
+        elseif length(x[1]) == 2 && isidentifier(x[1][2]) && valofid(x[1][2]) == "nospecialize"
             for i = 2:length(x)
                 if !ispunctuation(x[i])
                     if bindingof(x[i]) !== nothing
@@ -110,7 +110,7 @@ function _mark_JuMP_binding(arg)
 end
 
 function _points_to_Base_macro(x::EXPR, name, state)
-    length(x) == 2 && isidentifier(x[2]) && Symbol(valof(x[2])) == name && refof(x[2]) == getsymbolserver(state.server)[:Base][Symbol("@", name)]
+    length(x) == 2 && isidentifier(x[2]) && Symbol(valofid(x[2])) == name && refof(x[2]) == getsymbolserver(state.server)[:Base][Symbol("@", name)]
 end
 
 function _points_to_arbitrary_macro(x::EXPR, module_name, name, state)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -53,11 +53,11 @@ function handle_macro(x::EXPR, state)
                 end
             end
         elseif _points_to_arbitrary_macro(x[1], :Turing, :model, state) && length(x) == 2 && 
-            _binary_assert(x[2], CSTParser.Tokens.EQ) && 
+            is_binary_call(x[2], CSTParser.Tokens.EQ) && 
             _expr_assert(x[2][3], CSTParser.Begin, 3) && typof(x[2][3][2]) === CSTParser.Block
             for i = 1:length(x[2][3][2])
                 ex = x[2][3][2][i]
-                if typof(ex) == CSTParser.BinaryOpCall && kindof(ex[2]) === CSTParser.Tokens.APPROX
+                if is_binary_call(ex, CSTParser.Tokens.APPROX)
                     mark_binding!(ex)
                 end
             end
@@ -98,7 +98,7 @@ end
 function _mark_JuMP_binding(arg)
     if CSTParser.isidentifier(arg) || typof(arg) === CSTParser.Ref
         mark_binding!(_rem_ref(arg))
-    elseif _binary_assert(arg, CSTParser.Tokens.EQEQ) || _binary_assert(arg, CSTParser.Tokens.LESS_EQ)  || _binary_assert(arg, CSTParser.Tokens.GREATER_EQ)
+    elseif is_binary_call(arg, CSTParser.Tokens.EQEQ) || is_binary_call(arg, CSTParser.Tokens.LESS_EQ)  || is_binary_call(arg, CSTParser.Tokens.GREATER_EQ)
         if CSTParser.isidentifier(arg[1]) || typof(arg[1]) === CSTParser.Ref
             mark_binding!(_rem_ref(arg[1]))
         else

--- a/src/references.jl
+++ b/src/references.jl
@@ -182,7 +182,7 @@ end
 function resolve_getfield(x::EXPR, parent_type::EXPR, state::State)::Bool
     hasref(x) && return true
     resolved = false
-    if CSTParser.isidentifier(x)
+    if isidentifier(x)
         if CSTParser.defines_module(parent_type) && scopeof(parent_type) isa Scope
             resolved = resolve_ref(x, scopeof(parent_type), state, [])
         elseif CSTParser.defines_struct(parent_type)
@@ -219,7 +219,7 @@ end
 function resolve_getfield(x::EXPR, m::SymbolServer.ModuleStore, state::State)::Bool
     hasref(x) && return true
     resolved = false
-    if CSTParser.isidentifier(x) && (val = SymbolServer.maybe_getfield(Symbol(CSTParser.str_value(x)), m, getsymbolserver(state.server))) !== nothing
+    if isidentifier(x) && (val = SymbolServer.maybe_getfield(Symbol(CSTParser.str_value(x)), m, getsymbolserver(state.server))) !== nothing
         if val isa SymbolServer.VarRef
             val = SymbolServer._lookup(val, getsymbolserver(state.server))
             !(val isa SymbolServer.SymStore) && return false
@@ -233,7 +233,7 @@ end
 function resolve_getfield(x::EXPR, parent::SymbolServer.DataTypeStore, state::State)::Bool
     hasref(x) && return true
     resolved = false
-    if CSTParser.isidentifier(x) && Symbol(valof(x)) in parent.fieldnames
+    if isidentifier(x) && Symbol(valof(x)) in parent.fieldnames
         fi = findfirst(f->Symbol(valof(x)) == f, parent.fieldnames)
         ft = parent.types[fi]
         val = SymbolServer._lookup(ft, getsymbolserver(state.server))

--- a/src/references.jl
+++ b/src/references.jl
@@ -47,9 +47,9 @@ function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes)::Bool
         return resolve_getfield(x, scope, state)
     elseif typof(x) === CSTParser.Kw
         # Note to self: this seems wronge - Binding should be attached to entire Kw EXPR.
-        if typof(x[1]) === IDENTIFIER
+        if isidentifier(x[1])
             setref!(x[1], Binding(noname, nothing, nothing, [], nothing, nothing))
-        elseif is_declaration(x[1]) && typof(x[1][1]) === IDENTIFIER
+        elseif is_declaration(x[1]) && isidentifier(x[1][1])
             setref!(x[1][1], Binding(noname, nothing, nothing, [], nothing, nothing))
         end
         return true
@@ -244,7 +244,7 @@ function resolve_getfield(x::EXPR, parent::SymbolServer.DataTypeStore, state::St
     return resolved
 end
 
-resolvable_macroname(x::EXPR) = is_macroname(x) && length(x) == 2 && isidentifier(x[2]) && refof(x[2]) === nothing
+resolvable_macroname(x::EXPR) = is_macroname(x) && isidentifier(x[2]) && refof(x[2]) === nothing
 
 function _in_macro_def(x::EXPR)
     if typof(x) === CSTParser.Macro
@@ -263,8 +263,8 @@ Checks whether the scope is a module and we've visited it before,
 otherwise adds the module to the list.
 """
 function module_safety_trip(scope::Scope,  visited_scopes)
-    if CSTParser.defines_module(scope.expr) && CSTParser.length(scope.expr) > 1 && CSTParser.typof(scope.expr[2]) === IDENTIFIER
-        s_m_name = scope.expr[2].val isa String ? scope.expr[2].val : ""
+    if CSTParser.defines_module(scope.expr) && length(scope.expr) > 1 && isidentifier(scope.expr[2])
+        s_m_name = valofid(scope.expr[2])
         if s_m_name in visited_scopes
             return true
         else

--- a/src/references.jl
+++ b/src/references.jl
@@ -45,7 +45,7 @@ function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes)::Bool
 
     if is_getfield(x)
         return resolve_getfield(x, scope, state)
-    elseif typof(x) === CSTParser.Kw
+    elseif is_kwarg(x)
         # Note to self: this seems wronge - Binding should be attached to entire Kw EXPR.
         if isidentifier(x[1])
             setref!(x[1], Binding(noname, nothing, nothing, [], nothing, nothing))
@@ -247,7 +247,7 @@ end
 resolvable_macroname(x::EXPR) = is_macroname(x) && isidentifier(x[2]) && refof(x[2]) === nothing
 
 function _in_macro_def(x::EXPR)
-    if typof(x) === CSTParser.Macro
+    if CSTParser.defines_macro(x)
         return true
     elseif parentof(x) isa EXPR
         return _in_macro_def(parentof(x))

--- a/src/references.jl
+++ b/src/references.jl
@@ -99,7 +99,7 @@ function resolve_ref_from_module(x1::EXPR, m::SymbolServer.ModuleStore, state::S
                 return true
             end
         end
-    elseif typof(x1) === MacroName
+    elseif is_macroname(x1)
         x = x1[2]
         mn = Symbol("@", valof(x))
         if isexportedby(mn, m)
@@ -244,7 +244,7 @@ function resolve_getfield(x::EXPR, parent::SymbolServer.DataTypeStore, state::St
     return resolved
 end
 
-resolvable_macroname(x::EXPR) = typof(x) === MacroName && length(x) == 2 && isidentifier(x[2]) && refof(x[2]) === nothing
+resolvable_macroname(x::EXPR) = is_macroname(x) && length(x) == 2 && isidentifier(x[2]) && refof(x[2]) === nothing
 
 function _in_macro_def(x::EXPR)
     if typof(x) === CSTParser.Macro

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -65,10 +65,10 @@ function introduces_scope(x::EXPR, state)
     elseif is_where(x)
         # unless in func def signature
         return !_in_func_def(x)
-    elseif typof(x) === CSTParser.TupleH && length(x) > 2 && ispunctuation(x[1]) && is_assignment(x[2])
+    elseif is_tuple(x) && length(x) > 2 && ispunctuation(x[1]) && is_assignment(x[2])
         return true
     elseif typof(x) === CSTParser.FunctionDef ||
-            typof(x) === CSTParser.Macro ||
+        CSTParser.defines_macro(x)||
             typof(x) === CSTParser.For ||
             typof(x) === CSTParser.While ||
             typof(x) === CSTParser.Let ||

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -62,7 +62,7 @@ function introduces_scope(x::EXPR, state)
         else
             return false
         end
-    elseif typof(x) === CSTParser.WhereOpCall
+    elseif is_where(x)
         # unless in func def signature
         return !_in_func_def(x)
     elseif typof(x) === CSTParser.TupleH && length(x) > 2 && typof(x[1]) === CSTParser.PUNCTUATION && is_assignment(x[2])

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -65,7 +65,7 @@ function introduces_scope(x::EXPR, state)
     elseif is_where(x)
         # unless in func def signature
         return !_in_func_def(x)
-    elseif typof(x) === CSTParser.TupleH && length(x) > 2 && typof(x[1]) === CSTParser.PUNCTUATION && is_assignment(x[2])
+    elseif typof(x) === CSTParser.TupleH && length(x) > 2 && ispunctuation(x[1]) && is_assignment(x[2])
         return true
     elseif typof(x) === CSTParser.FunctionDef ||
             typof(x) === CSTParser.Macro ||

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -55,7 +55,7 @@ function introduces_scope(x::EXPR, state)
     if is_binary_call(x)
         if kindof(x[2]) === CSTParser.Tokens.EQ && CSTParser.is_func_call(x[1])
             return true
-        elseif kindof(x[2]) === CSTParser.Tokens.EQ && typof(x[1]) === CSTParser.Curly
+        elseif kindof(x[2]) === CSTParser.Tokens.EQ && is_curly(x[1])
             return true
         elseif kindof(x[2]) === CSTParser.Tokens.ANON_FUNC
             return true

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -111,7 +111,7 @@ function scopes(x::EXPR, state)
         setscope!(x, Scope(x))
     end
     s0 = state.scope
-    if typof(x) === FileH
+    if typof(x) === CSTParser.FileH
         setscope!(x, state.scope)
     elseif scopeof(x) isa Scope
         scopeof(x) != s0 && setparent!(scopeof(x), s0)

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -52,7 +52,7 @@ Does this expression introduce a new scope?
 """
 function introduces_scope(x::EXPR, state)
     #TODO: remove unused 2nd argument.
-    if typof(x) === CSTParser.BinaryOpCall
+    if is_binary_call(x)
         if kindof(x[2]) === CSTParser.Tokens.EQ && CSTParser.is_func_call(x[1])
             return true
         elseif kindof(x[2]) === CSTParser.Tokens.EQ && typof(x[1]) === CSTParser.Curly

--- a/src/server.jl
+++ b/src/server.jl
@@ -95,7 +95,7 @@ Usually called on the argument to `include` calls, and attempts to determine
 the path of the file to be included. Has limited support for `joinpath` calls.
 """
 function get_path(x::EXPR, state)
-    if typof(x) === Call && length(x) == 4
+    if is_call(x) && length(x) == 4
         parg = x[3]
         if CSTParser.is_lit_string(parg)
             path = CSTParser.str_value(parg)
@@ -106,7 +106,7 @@ function get_path(x::EXPR, state)
             path = normpath(CSTParser.str_value(parg[2]))
             Base.containsnul(path) && throw(SLInvalidPath("Couldn't convert '$x' into a valid path. Got '$path'"))
             return path
-        elseif typof(parg) === Call && isidentifier(parg[1]) && CSTParser.str_value(parg[1]) == "joinpath"
+        elseif is_call(parg) && isidentifier(parg[1]) && CSTParser.str_value(parg[1]) == "joinpath"
             path_elements = String[]
 
             for i = 2:length(parg)

--- a/src/server.jl
+++ b/src/server.jl
@@ -130,6 +130,6 @@ function get_path(x::EXPR, state)
     return ""
 end
 
-_is_macrocall_to_BaseDIR(arg) = typof(arg) === CSTParser.MacroCall && length(arg) == 1 &&
-    typof(arg[1]) === CSTParser.MacroName && length(arg[1]) == 2 &&
+_is_macrocall_to_BaseDIR(arg) = is_macro_call(arg) && length(arg) == 1 &&
+    is_macroname(arg[1]) &&
     valof(arg[1][2]) == "__DIR__"

--- a/src/server.jl
+++ b/src/server.jl
@@ -111,7 +111,7 @@ function get_path(x::EXPR, state)
 
             for i = 2:length(parg)
                 arg = parg[i]
-                if typof(arg) === PUNCTUATION
+                if ispunctuation(arg)
                 elseif _is_macrocall_to_BaseDIR(arg) # Assumes @__DIR__ points to Base macro.
                     push!(path_elements, dirname(getpath(state.file)))
                 elseif CSTParser.is_lit_string(arg)

--- a/src/server.jl
+++ b/src/server.jl
@@ -102,7 +102,7 @@ function get_path(x::EXPR, state)
             path = normpath(path)
             Base.containsnul(path) && throw(SLInvalidPath("Couldn't convert '$x' into a valid path. Got '$path'"))
             return path
-        elseif typof(parg) === x_Str && length(parg) == 2 && CSTParser.isidentifier(parg[1]) && valof(parg[1]) == "raw" && typof(parg[2]) === CSTParser.LITERAL && (kindof(parg[2]) == CSTParser.Tokens.STRING || kindof(parg[2]) == CSTParser.Tokens.TRIPLE_STRING)
+        elseif typof(parg) === x_Str && length(parg) == 2 && isidentifier(parg[1]) && valof(parg[1]) == "raw" && typof(parg[2]) === CSTParser.LITERAL && (kindof(parg[2]) == CSTParser.Tokens.STRING || kindof(parg[2]) == CSTParser.Tokens.TRIPLE_STRING)
             path = normpath(CSTParser.str_value(parg[2]))
             Base.containsnul(path) && throw(SLInvalidPath("Couldn't convert '$x' into a valid path. Got '$path'"))
             return path

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -28,7 +28,7 @@ function infer_type(binding::Binding, scope, state)
                     binding.type = CoreTypes.Float64
                 elseif kindof(binding.val[3]) === CSTParser.Tokens.STRING || typof(binding.val[3]) === CSTParser.Tokens.TRIPLE_STRING
                     binding.type = CoreTypes.String
-                elseif typof(binding.val[3]) === IDENTIFIER && refof(binding.val[3]) isa Binding
+                elseif isidentifier(binding.val[3]) && refof(binding.val[3]) isa Binding
                     binding.type = refof(binding.val[3]).type
                 end
             elseif kindof(binding.val[2]) === CSTParser.Tokens.DECLARATION

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -3,7 +3,7 @@ function infer_type(binding::Binding, scope, state)
         binding.type !== nothing && return
         if binding.val isa EXPR && CSTParser.defines_module(binding.val)
             binding.type = CoreTypes.Module
-        elseif binding.val isa EXPR && typof(binding.val) === CSTParser.FunctionDef
+        elseif binding.val isa EXPR && CSTParser.defines_function(binding.val)
             binding.type = CoreTypes.Function
         elseif binding.val isa EXPR && CSTParser.defines_datatype(binding.val)
             binding.type = CoreTypes.DataType
@@ -13,7 +13,7 @@ function infer_type(binding::Binding, scope, state)
                     binding.type = CoreTypes.Function
                 elseif CSTParser.is_func_call(binding.val[3])
                     callname = CSTParser.get_name(binding.val[3])
-                    if CSTParser.isidentifier(callname)
+                    if isidentifier(callname)
                         resolve_ref(callname, scope, state, [])
                         if hasref(callname)
                             rb = get_root_method(refof(callname), state.server)
@@ -26,17 +26,17 @@ function infer_type(binding::Binding, scope, state)
                     binding.type = CoreTypes.Int
                 elseif kindof(binding.val[3]) === CSTParser.Tokens.FLOAT
                     binding.type = CoreTypes.Float64
-                elseif kindof(binding.val[3]) === CSTParser.Tokens.STRING || typof(binding.val[3]) === CSTParser.Tokens.TRIPLE_STRING
+                elseif CSTParser.is_lit_string(binding.val[3])
                     binding.type = CoreTypes.String
                 elseif isidentifier(binding.val[3]) && refof(binding.val[3]) isa Binding
                     binding.type = refof(binding.val[3]).type
                 end
             elseif kindof(binding.val[2]) === CSTParser.Tokens.DECLARATION
                 t = binding.val[3]
-                if CSTParser.isidentifier(t)
+                if isidentifier(t)
                     resolve_ref(t, scope, state, [])
                 end
-                if typof(t) === CSTParser.Curly
+                if is_curly(t)
                     t = t[1]
                     resolve_ref(t, scope, state, [])
                 end

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -7,7 +7,7 @@ function infer_type(binding::Binding, scope, state)
             binding.type = CoreTypes.Function
         elseif binding.val isa EXPR && CSTParser.defines_datatype(binding.val)
             binding.type = CoreTypes.DataType
-        elseif binding.val isa EXPR && typof(binding.val) === BinaryOpCall
+        elseif binding.val isa EXPR && is_binary_call(binding.val)
             if kindof(binding.val[2]) === CSTParser.Tokens.EQ
                 if CSTParser.is_func_call(binding.val[1])
                     binding.type = CoreTypes.Function

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -369,3 +369,4 @@ is_getfield(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == CSTParser.To
 is_getfield_w_quotenode(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == CSTParser.Tokens.DOT && typof(x[3]) === CSTParser.Quotenode && length(x[3]) > 0 
 is_declaration(x::EXPR) = is_binary_call(x) && kindof(x[2]) === CSTParser.Tokens.DECLARATION
 is_where(x::EXPR) = typof(x) === CSTParser.WhereOpCall
+isnonstdid(x::EXPR) = typof(x) === CSTParser.NONSTDIDENTIFIER

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -271,7 +271,7 @@ isexportedby(x::EXPR, m::SymbolServer.ModuleStore) = isexportedby(valof(x), m)
 isexportedby(k, m::SymbolServer.ModuleStore) = false
 
 function retrieve_toplevel_scope(x)
-    if scopeof(x) !== nothing && (typof(x) === CSTParser.ModuleH || typof(x) === CSTParser.BareModule || typof(x) === CSTParser.FileH)
+    if scopeof(x) !== nothing && (CSTParser.defines_module(x) || typof(x) === CSTParser.FileH)
         return scopeof(x)
     elseif parentof(x) isa EXPR
         return retrieve_toplevel_scope(parentof(x))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -365,3 +365,4 @@ is_binary_call(x::EXPR, opkind) = is_binary_call(x) && kindof(x[2]) === opkind
 is_getfield(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == CSTParser.Tokens.DOT 
 is_getfield_w_quotenode(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == CSTParser.Tokens.DOT && typof(x[3]) === CSTParser.Quotenode && length(x[3]) > 0 
 is_declaration(x::EXPR) = is_binary_call(x) && kindof(x[2]) === CSTParser.Tokens.DECLARATION
+is_where(x::EXPR) = typof(x) === CSTParser.WhereOpCall

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -362,6 +362,9 @@ is_call(x::EXPR) = typof(x) === CSTParser.Call
 is_unary_call(x::EXPR) = typof(x) === CSTParser.UnaryOpCall && length(x) == 2
 is_binary_call(x::EXPR) = typof(x) === CSTParser.BinaryOpCall && length(x) == 3
 is_binary_call(x::EXPR, opkind) = is_binary_call(x) && kindof(x[2]) === opkind
+is_macro_call(x::EXPR) = typof(x) === CSTParser.MacroCall
+is_macroname(x::EXPR) = typof(x) === CSTParser.MacroName && length(x) == 2
+is_id_or_macroname(x::EXPR) = isidentifier(x) || is_macroname(x)
 is_getfield(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == CSTParser.Tokens.DOT 
 is_getfield_w_quotenode(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == CSTParser.Tokens.DOT && typof(x[3]) === CSTParser.Quotenode && length(x[3]) > 0 
 is_declaration(x::EXPR) = is_binary_call(x) && kindof(x[2]) === CSTParser.Tokens.DECLARATION

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 quoted(x) = typof(x) === Quote || typof(x) === Quotenode
-unquoted(x) = is_unary_call(x) && typof(x[1]) === OPERATOR && kindof(x[1]) == CSTParser.Tokens.EX_OR
+unquoted(x) = is_unary_call(x) && isoperator(x[1]) && kindof(x[1]) == CSTParser.Tokens.EX_OR
 
 function get_ids(x, q = false, ids = [])
     if quoted(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -173,10 +173,6 @@ end
 function _expr_assert(x::EXPR, typ, nargs)
     typof(x) == typ && length(x) == nargs
 end
-
-function _binary_assert(x, kind)
-    typof(x) === CSTParser.BinaryOpCall && length(x) == 3 && typof(x[2]) === CSTParser.OPERATOR && kindof(x[2]) === kind
-end
     
 # should only be called on Bindings to functions
 function last_method(func::Binding)
@@ -361,8 +357,11 @@ function iterate_over_ss_methods(b::SymbolServer.DataTypeStore, tls::Scope, serv
 end
 
 # CST utils
-fcall_name(x::EXPR) = typof(x) === Call && length(x) > 0 && valof(x[1])
-is_binary_call(x::EXPR) = typof(x) === BinaryOpCall && length(x) == 3
+fcall_name(x::EXPR) = is_call(x) && length(x) > 0 && valof(x[1])
+is_call(x::EXPR) = typof(x) === CSTParser.Call
+is_unary_call(x::EXPR) = typof(x) === CSTParser.UnaryOpCall && length(x) == 2
+is_binary_call(x::EXPR) = typof(x) === CSTParser.BinaryOpCall && length(x) == 3
+is_binary_call(x::EXPR, opkind) = is_binary_call(x) && kindof(x[2]) === opkind
 is_getfield(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == CSTParser.Tokens.DOT 
 is_getfield_w_quotenode(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == CSTParser.Tokens.DOT && typof(x[3]) === CSTParser.Quotenode && length(x[3]) > 0 
 is_declaration(x::EXPR) = is_binary_call(x) && kindof(x[2]) === CSTParser.Tokens.DECLARATION

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -60,7 +60,7 @@ function clear_scope(x::EXPR)
     if hasmeta(x) && scopeof(x) isa Scope
         setparent!(scopeof(x), nothing)
         empty!(scopeof(x).names)
-        if typof(x) === FileH && scopeof(x).modules isa Dict && scopehasmodule(scopeof(x), :Base) && scopehasmodule(scopeof(x), :Core)
+        if typof(x) === CSTParser.FileH && scopeof(x).modules isa Dict && scopehasmodule(scopeof(x), :Base) && scopehasmodule(scopeof(x), :Core)
             m1, m2 = getscopemodule(scopeof(x), :Base), getscopemodule(scopeof(x), :Core)
             empty!(scopeof(x).modules)
             addmoduletoscope!(scopeof(x), m1)
@@ -371,4 +371,5 @@ is_declaration(x::EXPR) = is_binary_call(x) && kindof(x[2]) === CSTParser.Tokens
 is_where(x::EXPR) = typof(x) === CSTParser.WhereOpCall
 isnonstdid(x::EXPR) = typof(x) === CSTParser.NONSTDIDENTIFIER
 is_kwarg(x::EXPR) = typof(x) === CSTParser.Kw
+is_parameters(x::EXPR) = typof(x) === CSTParser.Parameters
 is_tuple(x::EXPR) = typof(x) === CSTParser.TupleH

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 quoted(x) = typof(x) === Quote || typof(x) === Quotenode
-unquoted(x) = typof(x) === UnaryOpCall && typof(x[1]) === OPERATOR && kindof(x[1]) == CSTParser.Tokens.EX_OR
+unquoted(x) = is_unary_call(x) && typof(x[1]) === OPERATOR && kindof(x[1]) == CSTParser.Tokens.EX_OR
 
 function get_ids(x, q = false, ids = [])
     if quoted(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -151,7 +151,7 @@ function find_return_statements(x::EXPR)
 end
 
 function find_return_statements(x::EXPR, last_stmt, rets)
-    if last_stmt && !(typof(x) === CSTParser.Block || typof(x) === CSTParser.If || typof(x) === CSTParser.KEYWORD)
+    if last_stmt && !(typof(x) === CSTParser.Block || typof(x) === CSTParser.If || iskw(x))
         push!(rets, x)
         return rets, false
     end 
@@ -370,3 +370,5 @@ is_getfield_w_quotenode(x) = x isa EXPR && is_binary_call(x) && kindof(x[2]) == 
 is_declaration(x::EXPR) = is_binary_call(x) && kindof(x[2]) === CSTParser.Tokens.DECLARATION
 is_where(x::EXPR) = typof(x) === CSTParser.WhereOpCall
 isnonstdid(x::EXPR) = typof(x) === CSTParser.NONSTDIDENTIFIER
+is_kwarg(x::EXPR) = typof(x) === CSTParser.Kw
+is_tuple(x::EXPR) = typof(x) === CSTParser.TupleH

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -214,7 +214,7 @@ function find_exported_names(x::EXPR)
         expr = x[3][i]
         if typof(expr) == CSTParser.Export && 
             for j = 2:length(expr)
-                if CSTParser.isidentifier(expr[j]) && hasref(expr[j])
+                if isidentifier(expr[j]) && hasref(expr[j])
                     push!(exported_vars, expr[j])
                 end
             end
@@ -373,3 +373,4 @@ isnonstdid(x::EXPR) = typof(x) === CSTParser.NONSTDIDENTIFIER
 is_kwarg(x::EXPR) = typof(x) === CSTParser.Kw
 is_parameters(x::EXPR) = typof(x) === CSTParser.Parameters
 is_tuple(x::EXPR) = typof(x) === CSTParser.TupleH
+is_curly(x::EXPR) = typof(x) === CSTParser.Curly

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -374,3 +374,4 @@ is_kwarg(x::EXPR) = typof(x) === CSTParser.Kw
 is_parameters(x::EXPR) = typof(x) === CSTParser.Parameters
 is_tuple(x::EXPR) = typof(x) === CSTParser.TupleH
 is_curly(x::EXPR) = typof(x) === CSTParser.Curly
+is_invis_brackets(x::EXPR) = typof(x) === CSTParser.InvisBrackets

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -925,6 +925,21 @@ end
         @test bindingof(cst[1][3][1][3][1]) == refof(cst[1][3][3][2][3][3][3][1])
     end 
 end
-
+@testset "misc" begin # e.g. `using StaticLint: StaticLint`
+    let cst = parse_and_pass("""
+        import Base: Bool
+        function Bool(x) x end
+        ^(z::Complex, n::Bool) = n ? z : one(z)
+        """)
+        StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
+        @test isempty(StaticLint.collect_hints(cst, server))
+    end
+    let cst = parse_and_pass("""
+        (rand(d::Vector{T})::T) where {T}  =  1
+        """)
+        StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
+        @test isempty(StaticLint.collect_hints(cst, server))
+    end
+end
 end
 


### PR DESCRIPTION
Looks substantial but shouldn't be
- Makes a few fixes for non-standard identifiers that weren't handled previously.
- Fixes an issue with the declaration of datatype check.
- Fixes an issue where function signatures wrapped in brackets weren't being handled properly.
- Tidying up - in particular I'm trying to get to the point where StaticLint is agnostic as to the format of expressions structs. Some newly defined functions will be moved to CSTParser at some point. More interestingly this was all done automatically with a tool for function extraction. This analyses a given expression, identifies which variables are local to the scope of that expression and sets them as arguments. It then replaces the existing initial expression as well as any others in the project that match it (i.e. matching semantic info of the expression, not just the syntactical structure). It'll need  a fair bit of work before t could be added to the languageserver actions
