### PR TITLE
Explicitly resolve `new` within struct defs

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -60,7 +60,7 @@ function (state::Toplevel)(x::EXPR)
     mark_globals(x, state)
     handle_macro(x, state)
     s0 = scopes(x, state)
-    _resolve_ref(x, state)
+    resolve_ref(x, state)
     followinclude(x, state)
 
     if CSTParser.defines_function(x) || CSTParser.defines_macro(x) || typof(x) === CSTParser.Export
@@ -84,7 +84,7 @@ function (state::Delayed)(x::EXPR)
     mark_globals(x, state)
     handle_macro(x, state)
     s0 = scopes(x, state)
-    _resolve_ref(x, state)
+    resolve_ref(x, state)
 
     traverse(x, state)
     

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -54,7 +54,7 @@ function mark_bindings!(x::EXPR, state)
                 end
             elseif is_curly(x[1])
                 mark_typealias_bindings!(x)
-            else
+            elseif !is_getfield(x[1])
                 mark_binding!(x[1], x)
             end
         elseif kindof(x[2]) === CSTParser.Tokens.ANON_FUNC

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -54,7 +54,7 @@ function handle_macro(x::EXPR, state)
             end
         elseif _points_to_arbitrary_macro(x[1], :Turing, :model, state) && length(x) == 2 && 
             is_binary_call(x[2], CSTParser.Tokens.EQ) && 
-            _expr_assert(x[2][3], CSTParser.Begin, 3) && typof(x[2][3][2]) === CSTParser.Block
+            typof(x[2][3]) === CSTParser.Begin && length(x[2][3]) == 3 && typof(x[2][3][2]) === CSTParser.Block
             for i = 1:length(x[2][3][2])
                 ex = x[2][3][2][i]
                 if is_binary_call(ex, CSTParser.Tokens.APPROX)

--- a/src/references.jl
+++ b/src/references.jl
@@ -18,7 +18,7 @@ end
 # refers to. If it remains unresolved and is in a delayed evaluation scope 
 # (i.e. a function) it gets pushed to list (.urefs) to be resolved after we've
 # run over the entire top-level scope.
-function _resolve_ref(x, state)
+function resolve_ref(x, state)
     if !(parentof(x) isa EXPR && typof(parentof(x)) == CSTParser.Quotenode)
         resolved = resolve_ref(x, state.scope, state, [])
     end

--- a/src/references.jl
+++ b/src/references.jl
@@ -53,7 +53,7 @@ function resolve_ref(x::EXPR, scope::Scope, state::State, visited_scopes)::Bool
             setref!(x[1][1], Binding(noname, nothing, nothing, [], nothing, nothing))
         end
         return true
-    elseif isidentifier(x) && (valofid(x) == "__source__" || valofid(x) == "__module__") && _in_macro_def(x)
+    elseif is_special_macro_term(x) || new_within_struct(x)
         setref!(x, Binding(noname, nothing, nothing, [], nothing, nothing))
         return true
     end
@@ -246,16 +246,6 @@ end
 
 resolvable_macroname(x::EXPR) = is_macroname(x) && isidentifier(x[2]) && refof(x[2]) === nothing
 
-function _in_macro_def(x::EXPR)
-    if CSTParser.defines_macro(x)
-        return true
-    elseif parentof(x) isa EXPR
-        return _in_macro_def(parentof(x))
-    else
-        return false
-    end
-end
-
 """
     module_safety_trip(scope::Scope,  visited_scopes)
 
@@ -298,3 +288,11 @@ Returns the string value of an expression for which `isidentifier` is true,
 i.e. handles NONSTDIDENTIFIERs.
 """
 valofid(x::EXPR) = typof(x) === CSTParser.IDENTIFIER ? valof(x) : valof(x[2])
+
+"""
+new_within_struct(x::EXPR)
+
+Checks whether x is a reference to `new` within a datatype constructor. 
+"""
+new_within_struct(x::EXPR) = isidentifier(x) && valofid(x) == "new" && is_in_fexpr(x, CSTParser.defines_struct)
+is_special_macro_term(x::EXPR) = isidentifier(x) && (valofid(x) == "__source__" || valofid(x) == "__module__") && is_in_fexpr(x, CSTParser.defines_macro)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -227,15 +227,7 @@ end
     is_in_fexpr(x::EXPR, f)
 Check whether `x` isa the child of an expression for which `f(parent) == true`.
 """
-function is_in_fexpr(x::EXPR, f)
-    if f(x)
-        return true
-    elseif parentof(x) isa EXPR
-        return is_in_fexpr(parentof(x), f)
-    else
-        return false
-    end
-end
+is_in_fexpr(x::EXPR, f) = f(x) || (parentof(x) isa EXPR && is_in_fexpr(parentof(x), f))
 
 """
     get_in_fexpr(x::EXPR, f)
@@ -254,7 +246,7 @@ hasreadperm(p::String) = (uperm(p) & 0x04) == 0x04
 # check whether a path is in (including subfolders) the julia base dir. Returns "" if not, and the path to the base dir if so.
 function _is_in_basedir(path::String)
     i = findfirst(r".*base", path)
-    i == nothing && return ""
+    i === nothing && return ""
     path1 = path[i]::String
     !hasreadperm(path1) && return ""
     !isdir(path1) && return ""


### PR DESCRIPTION
Explicit handling of `new` (it was previously handled as a keyword in CSTParser which wasn't quite right).

Also some more tidying - should be all cosmetic.