### PR TITLE
Ensure we follow VarRefs to the object they point at

### DIFF
--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -302,7 +302,7 @@ function add_binding(x, state, scope = state.scope)
                             if scopehasmodule(s1, Symbol(valofid(parentof(parentof(bindingof(x).name))[1]))) # this scope (s1) has a module with matching name
                                 mod = getscopemodule(s1, Symbol(valofid(parentof(parentof(bindingof(x).name))[1])))
                                 if mod isa SymbolServer.ModuleStore && haskey(mod, Symbol(name))
-                                    bindingof(x).prev = mod[Symbol(name)]
+                                    bindingof(x).prev = maybe_lookup(mod[Symbol(name)], state.server)
                                 end
                             end
                             break # We've reached a scope that loads modules, no need to keep searching upwards

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -128,7 +128,7 @@ end
 
 function func_nargs(m::SymbolServer.MethodStore)
     minargs, maxargs, kws, kwsplat = 0, 0, Symbol[], false
-    
+
     for arg in m.sig
         if CoreTypes.isva(last(arg))
             maxargs = typemax(Int)

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -551,13 +551,13 @@ function has_getproperty_method(b::SymbolServer.DataTypeStore, server)
         for ext in getsymbolextendeds(server)[getprop_vr]
             for m in SymbolServer._lookup(ext, getsymbolserver(server))[:getproperty].methods
                 t = unwrap_fakeunionall(m.sig[1][2])
-                t.name == b.name.name && return true
+                !(t isa SymbolServer.FakeUnion) && t.name == b.name.name && return true
             end
         end
     else
         for m in getsymbolserver(server)[:Base][:getproperty].methods
             t = unwrap_fakeunionall(m.sig[1][2])
-            t.name == b.name.name && return true
+            !(t isa SymbolServer.FakeUnion) && t.name == b.name.name && return true
         end
     end
     return false

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -110,9 +110,11 @@ function _mark_JuMP_binding(arg)
 end
 
 function _points_to_Base_macro(x::EXPR, name, state)
-    length(x) == 2 && isidentifier(x[2]) && Symbol(valofid(x[2])) == name && refof(x[2]) == getsymbolserver(state.server)[:Base][Symbol("@", name)]
+    length(x) == 2 && isidentifier(x[2]) && Symbol(valofid(x[2])) == name && refof(x[2]) == maybe_lookup(getsymbolserver(state.server)[:Base][Symbol("@", name)], state.server)
 end
 
 function _points_to_arbitrary_macro(x::EXPR, module_name, name, state)
-    length(x) == 2 && isidentifier(x[2]) && valof(x[2]) == name && haskey(getsymbolserver(state.server), Symbol(module_name)) && haskey(getsymbolserver(state.server)[Symbol(module_name)], Symbol("@", name)) && refof(x[2]) == getsymbolserver(state.server)[Symbol(module_name)][Symbol("@", name)]
+    length(x) == 2 && isidentifier(x[2]) && valof(x[2]) == name && haskey(getsymbolserver(state.server), Symbol(module_name)) && haskey(getsymbolserver(state.server)[Symbol(module_name)], Symbol("@", name)) && refof(x[2]) == maybe_lookup(getsymbolserver(state.server)[Symbol(module_name)][Symbol("@", name)], state.server)
 end
+
+maybe_lookup(x, server) = x isa SymbolServer.VarRef ? SymbolServer._lookup(x, getsymbolserver(server), true) : x

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -229,6 +229,10 @@ end
 
 iterate_over_ss_methods(b, tls, server, f) = false
 function iterate_over_ss_methods(b::SymbolServer.FunctionStore, tls::Scope, server, f)
+    for m in b.methods
+        ret = f(m)
+        ret && return true
+    end
     if b.extends in keys(getsymbolextendeds(server)) && tls.modules !== nothing
         # above should be modified, 
         rootmod = SymbolServer._lookup(b.extends.parent, getsymbolserver(server)) # points to the module containing the initial function declaration
@@ -249,11 +253,6 @@ function iterate_over_ss_methods(b::SymbolServer.FunctionStore, tls::Scope, serv
                 end
             end
         end
-    else
-        for m in b.methods
-            ret = f(m)
-            ret && return true
-        end
     end
     return false
 end
@@ -264,9 +263,13 @@ function iterate_over_ss_methods(b::SymbolServer.DataTypeStore, tls::Scope, serv
     elseif b.name isa SymbolServer.FakeTypeName
         bname = b.name.name
     end
+    for m in b.methods
+        ret = f(m)
+        ret && return true
+    end
     if (bname in keys(getsymbolextendeds(server))) && tls.modules !== nothing
         # above should be modified, 
-        rootmod = SymbolServer._lookup(bname.parent, getsymbolserver(server)) # points to the module containing the initial function declaration
+        rootmod = SymbolServer._lookup(bname.parent, getsymbolserver(server), true) # points to the module containing the initial function declaration
         if rootmod !== nothing && haskey(rootmod, bname.name) # check rootmod exists, and that it has the variable
             rootfunc = rootmod[bname.name]
             # find extensoions
@@ -283,11 +286,6 @@ function iterate_over_ss_methods(b::SymbolServer.DataTypeStore, tls::Scope, serv
                     end
                 end
             end
-        end
-    else
-        for m in b.methods
-            ret = f(m)
-            ret && return true
         end
     end
     return false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -819,7 +819,7 @@ end
         T() = 1
         """)
         StaticLint.check_const_redef(cst[2])
-        @test cst[2].meta.error == nothing
+        @test cst[2].meta.error === nothing
     end
 end
 


### PR DESCRIPTION
`SymbolServer.VarRef`s are used to point at objects in a SymbolServer cache of a collection of packages. Except where used within `SymbolServer.SymStore` objects, we don't want them exposed elsewhere in StaticLint - this PR removes a few instances where they could be introduced.

Also, a fix for the order in which we iterate over function methods