### PR TITLE
Bug fixes: method overloading, import/exports, add macro handler

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -4,6 +4,7 @@ include("exception_types.jl")
 
 using SymbolServer, CSTParser
 using CSTParser: EXPR, isidentifier, Import, Using, Export, Quote, Quotenode, x_Str, FunctionDef, setparent!, kindof, valof, typof, parentof, is_assignment, isoperator, ispunctuation, iskw, defines_function
+using SymbolServer: VarRef
 
 const noname = EXPR(CSTParser.NoHead, nothing, 0, 0, nothing, CSTParser.NoKind, false, nothing, nothing)
 baremodule CoreTypes # Convenience

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -354,7 +354,7 @@ eventually_overloads(b::Binding, ss::SymbolServer.SymStore, server) = (b.val == 
 
 eventually_overloads(b::Binding, ss::SymbolServer.VarRef, server) = eventually_overloads(b, maybe_lookup(ss, server), server)
 
-eventually_overloads(b::Binding, ss, server) = false
+eventually_overloads(b, ss, server) = false
 
 
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -89,7 +89,7 @@ function add_to_imported_modules(scope::Scope, name::Symbol, val)
 end
 no_modules_above(s::Scope) = !CSTParser.defines_module(s.expr) || s.parent === nothing || no_modules_above(s.parent)
 function get_named_toplevel_module(s::Scope, name::String) 
-    if s.ismodule && valofid(CSTParser.get_name(s.expr)) == name && no_modules_above(s)
+    if CSTParser.defines_module(s.expr) && valofid(CSTParser.get_name(s.expr)) == name && no_modules_above(s)
         return s.expr
     elseif s.parent isa Scope
         return get_named_toplevel_module(s.parent, name)

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -113,6 +113,11 @@ function _get_field(par, arg, state)
             end
             return par
         end
+        for used_module in par.used_modules
+            if isexportedby(arg_str_rep, used_module)
+                return used_module[Symbol(arg_str_rep)]
+            end
+        end
     elseif par isa Scope && scopehasbinding(par, arg_str_rep)
         return par.names[arg_str_rep]
     elseif par isa Binding

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -5,7 +5,6 @@ function resolve_import(x, state::State)
         n = length(x)
         
         root = par = getsymbolserver(state.server)
-        bindings = []
         while i <= n
             arg = x[i]
             if is_id_or_macroname(arg)

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -113,8 +113,9 @@ function _get_field(par, arg, state)
             end
             return par
         end
-        for used_module in par.used_modules
-            if isexportedby(arg_str_rep, used_module)
+        for used_module_name in par.used_modules
+            used_module = maybe_lookup(par[used_module_name], getsymbolserver(state.server))
+            if isexportedby(Symbol(arg_str_rep), used_module)
                 return used_module[Symbol(arg_str_rep)]
             end
         end

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -320,7 +320,7 @@ function _get_top_binding(s::Scope, name::String)
 end
 
 function _get_global_scope(s::Scope)
-    if !s.ismodule && parentof(s) isa Scope && parentof(s) != s
+    if !CSTParser.defines_module(s.expr) && parentof(s) isa Scope && parentof(s) != s
         return _get_global_scope(parentof(s))
     else
         return s

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -12,7 +12,7 @@ function handle_macro(x::EXPR, state)
                 mark_binding!(x[2], x)
                 mark_sig_args!(x[2])
                 s0 = state.scope # store previous scope
-                state.scope = Scope(s0, x, Dict(), nothing, false)
+                state.scope = Scope(s0, x, Dict(), nothing, nothing)
                 setscope!(x, state.scope) # tag new scope to generating expression
                 state(x[2])
                 state(x[3])

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -20,6 +20,8 @@ function handle_macro(x::EXPR, state)
             elseif isidentifier(x[2])
                 mark_binding!(x[2], x)
             end
+        elseif _points_to_Base_macro(x[1], :deprecate_binding, state) && length(x) == 3 && isidentifier(x[2]) && isidentifier(x[3])
+            setref!(x[2], refof(x[3]))
         elseif _points_to_Base_macro(x[1], :eval, state) && length(x) == 2 && state isa Toplevel
             # Create scope around eval'ed expression. This ensures anybindings are
             # correctly hoisted to the top-level scope.

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -10,7 +10,7 @@ function Base.show(io::IO, s::Scope)
     printstyled(io, typof(s.expr))
     printstyled(io, " ", join(keys(s.names), ","), color = :yellow)
     s.modules isa Dict && printstyled(io, " ", join(keys(s.modules), ","), color = :blue)
-    println(io)
+    # println(io)
 end
 
 function overload_method(scope::Scope, b::Binding, vr::SymbolServer.VarRef)

--- a/src/server.jl
+++ b/src/server.jl
@@ -40,7 +40,7 @@ getsymbolextendeds(server::FileServer) = server.symbol_extends
 
 function scopepass(file, target = nothing)
     server = file.server
-    setscope!(getcst(file), Scope(nothing, getcst(file), Dict(), Dict{Symbol,Any}(:Base => getsymbolserver(server)[:Base], :Core => getsymbolserver(server)[:Core]), false))
+    setscope!(getcst(file), Scope(nothing, getcst(file), Dict(), Dict{Symbol,Any}(:Base => getsymbolserver(server)[:Base], :Core => getsymbolserver(server)[:Core]), nothing))
     state = Toplevel(file, target, [getpath(file)], scopeof(getcst(file)), EXPR[], server)
     state(getcst(file))
     for x in state.delayed

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,6 +38,9 @@ function clear_scope(x::EXPR)
         else
             scopeof(x).modules = nothing
         end
+        if scopeof(x).overloaded !== nothing
+            empty!(scopeof(x).overloaded)
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -869,11 +869,27 @@ f(arg) = arg
         end
     end
 
-    @testset "using of self" begin # e.g. `using StaticLint: StaticLint`
+    @testset "using statements" begin # e.g. `using StaticLint: StaticLint`
         let cst = parse_and_pass("""
         using Base.Filesystem: Filesystem
         """)
             @test StaticLint.hasref(cst[1][6])
+        end
+        let cst = parse_and_pass("""
+            using Base: Ordering
+            """)
+            @test StaticLint.hasbinding(cst[1][4])
+        end
+        let cst = parse_and_pass("""
+            module Outer
+            module Inner
+            export x
+            x = 1
+            end
+            end
+            using Outer: x
+            """)
+            @test StaticLint.hasbinding(cst[2][4])
         end
     end
 
@@ -1190,8 +1206,6 @@ end
             end
             end""")
         @test refof(cst[1][3][3][3][2]) !== nothing
-        
     end
-
 end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -883,13 +883,15 @@ f(arg) = arg
         let cst = parse_and_pass("""
             module Outer
             module Inner
-            export x
             x = 1
+            export x
             end
+            using .Inner
             end
-            using Outer: x
+            using .Outer: x, rand
             """)
-            @test StaticLint.hasbinding(cst[2][4])
+            @test StaticLint.hasbinding(cst[2][5])
+            @test StaticLint.hasbinding(cst[2][7])
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1084,21 +1084,21 @@ let cst = parse_and_pass("""
 end
 
 @testset "quoted getfield" begin
-let cst = parse_and_pass("""
-    Base.:sin
-    """)
-    StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
-    @test isempty(StaticLint.collect_hints(cst[1], server))
-end
+    let cst = parse_and_pass("""
+        Base.:sin
+        """)
+        StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
+        @test isempty(StaticLint.collect_hints(cst[1], server))
+    end
 
-let cst = parse_and_pass("""
-    sin(1,1)
-    Base.sin(1,1)
-    Base.:sin(1,1)
-    """)
-    StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
-    @test errorof(cst[1]) === errorof(cst[2]) === errorof(cst[3])
-end
+    let cst = parse_and_pass("""
+        sin(1,1)
+        Base.sin(1,1)
+        Base.:sin(1,1)
+        """)
+        StaticLint.check_all(cst, StaticLint.LintOptions(:), server)
+        @test errorof(cst[1]) === errorof(cst[2]) === errorof(cst[3])
+    end
 end
 @testset "overloading" begin
     # overloading of a function that happens to be exported into the current scope.
@@ -1161,5 +1161,21 @@ end
         @test isempty(StaticLint.collect_hints(cst, server))
         
     end
+end
+
+@testset "on demand resolving of export statements" begin
+    let cst = parse_and_pass("""
+            module TopModule
+            abstract type T end
+            export T
+            module SubModule
+            using ..TopModule
+            T
+            end
+            end""")
+        @test refof(cst[1][3][3][3][2]) !== nothing
+        
+    end
+
 end
 end


### PR DESCRIPTION
Fixes a number of bugs:
- Improves the handling of method overloading through the use of qualified names (i.e. `Module.func`). Takes proper account of whether the function is exported to the current scope/namespace.
-Resolve exports on demand. Export statements can include variables that are defined later within the code but we still need to calculate what _is_ exported as needed.
-Adds custom handles for `deprecate_binding`.

