### PR TITLE
fic call check (remove surround type info from func sigs)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1"
-CSTParser = "2.1"
+CSTParser = "2.3.1"
 SymbolServer = "4.3"
 
 [targets]

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -86,7 +86,7 @@ end
 
 function func_nargs(x::EXPR)
     minargs, maxargs, kws, kwsplat = 0, 0, Symbol[], false
-    sig = CSTParser.rem_where_decl(CSTParser.get_sig(x))
+    sig = rem_wheres_decls(CSTParser.get_sig(x))
     for i = 2:length(sig)
         arg = sig[i]
         if is_macro_call(arg) && length(arg) > 1 &&

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -283,6 +283,7 @@ is_curly(x::EXPR) = typof(x) === CSTParser.Curly
 is_invis_brackets(x::EXPR) = typof(x) === CSTParser.InvisBrackets
 iswherecall(x::EXPR) = typof(x) === CSTParser.WhereOpCall
 rem_wheres(x::EXPR) = iswherecall(x) ? rem_wheres(x[1]) : x
+rem_wheres_decls(x::EXPR) = iswherecall(x) || CSTParser.isdeclaration(x) ? rem_wheres_decls(x[1]) : x
 hasparent(x::EXPR) = parentof(x) isa EXPR
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -651,7 +651,7 @@ f(arg) = arg
             @test isempty(StaticLint.collect_hints(cst, server))
         end
         let cst = parse_and_pass("""
-            function f(a)::Bool where {F} end
+            function f(a::F)::Bool where {F} end
             """)
             # ensure we strip all type decl code from around signature
             StaticLint.check_all(cst, StaticLint.LintOptions(), server)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -650,6 +650,13 @@ f(arg) = arg
             StaticLint.check_all(cst, StaticLint.LintOptions(), server)
             @test isempty(StaticLint.collect_hints(cst, server))
         end
+        let cst = parse_and_pass("""
+            function f(a)::Bool where {F} end
+            """)
+            # ensure we strip all type decl code from around signature
+            StaticLint.check_all(cst, StaticLint.LintOptions(), server)
+            @test isempty(StaticLint.collect_hints(cst, server))
+        end
     end
 
     @testset "check_modulename" begin


### PR DESCRIPTION
closes #184 