### PR TITLE
Check default value of kwargs matches given type

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -14,6 +14,7 @@ const DataType = SymbolServer.stdlibs[:Core][:DataType]
 const Function = SymbolServer.stdlibs[:Core][:Function]
 const Module = SymbolServer.stdlibs[:Core][:Module]
 const String = SymbolServer.stdlibs[:Core][:String]
+const Symbol = SymbolServer.stdlibs[:Core][:Symbol]
 const Int = SymbolServer.stdlibs[:Core][:Int]
 const Float64 = SymbolServer.stdlibs[:Core][:Float64]
 const Vararg = SymbolServer.FakeTypeName(Core.Vararg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1217,4 +1217,54 @@ f(arg) = arg
             @test refof(cst[1][3][3][3][2]) !== nothing
         end
     end
+
+    @testset "on demand resolving of export statements" begin
+        cst = parse_and_pass("f(x::Float64 = 0.1)")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) === nothing
+        
+        cst = parse_and_pass("f(x::Float64 = f())")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) === nothing
+
+        cst = parse_and_pass("f(x::Float64 = 1)")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) == StaticLint.KwDefaultMismatch
+
+        cst = parse_and_pass("f(x::Int = 1)")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) === nothing
+        
+        cst = parse_and_pass("f(x::Int = f())")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) === nothing
+        
+        cst = parse_and_pass("f(x::Int = 0.1)")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) == StaticLint.KwDefaultMismatch
+
+        cst = parse_and_pass("f(x::String = \"1\")")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) === nothing
+        
+        cst = parse_and_pass("f(x::String = f())")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) === nothing
+        
+        cst = parse_and_pass("f(x::String = 0.1)")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) == StaticLint.KwDefaultMismatch
+
+        cst = parse_and_pass("f(x::Symbol = :x)")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) === nothing
+        
+        cst = parse_and_pass("f(x::Symbol = f())")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) === nothing
+        
+        cst = parse_and_pass("f(x::Symbol = \"a\")")
+        StaticLint.check_kw_default(cst[1][3], server)
+        @test errorof(cst[1][3][3]) == StaticLint.KwDefaultMismatch
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1267,6 +1267,7 @@ f(arg) = arg
         cst = parse_and_pass("f(x::Symbol = \"a\")")
         StaticLint.check_kw_default(cst[1][3], server)
         @test errorof(cst[1][3][3]) == StaticLint.KwDefaultMismatch
+    end
 
     @testset "check_use_of_literal" begin
         let cst = parse_and_pass("""


### PR DESCRIPTION
Check for `f(a::Int = "not an Int")`. Is restricted to operate on types: (String,Symbol,Int,Float64) for the declarations and where the rhs is a literal