### PR TITLE
modify isexportedby

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 julia = "1"
 CSTParser = "2.3.1"
-SymbolServer = "4.3"
+SymbolServer = "5"
 
 [targets]
 test = ["Test", "Pkg", "SHA", "LibGit2"]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -175,7 +175,7 @@ function _is_in_basedir(path::String)
     return ""
 end
 
-isexportedby(k::Symbol, m::SymbolServer.ModuleStore) = haskey(m, k) && ((m[k] isa SymbolServer.SymStore && m[k].exported) || k in m.exportednames)
+isexportedby(k::Symbol, m::SymbolServer.ModuleStore) = haskey(m, k) && k in m.exportednames
 isexportedby(k::String, m::SymbolServer.ModuleStore) = isexportedby(Symbol(k), m)
 isexportedby(x::EXPR, m::SymbolServer.ModuleStore) = isexportedby(valof(x), m)
 isexportedby(k, m::SymbolServer.ModuleStore) = false


### PR DESCRIPTION
Simplify interface - only use .exportednames field. Possibly paves the way for removal of the .exported field in the future (which doesn't really make sense to be attached to the object)