### PR TITLE
fewer false positives in include

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -143,7 +143,7 @@ If this is successful it traverses the code associated with the loaded file.
 """
 function followinclude(x, state::State)
     if is_call(x) && length(x) > 0 && isidentifier(x[1]) && valofid(x[1]) == "include"
-        path = get_path(x, state)
+        init_path = path = get_path(x, state)
         if isempty(path)
         elseif isabspath(path)
             if hasfile(state.server, path)
@@ -188,7 +188,7 @@ function followinclude(x, state::State)
             state(getcst(state.file))
             state.file = oldfile
             pop!(state.included_files)
-        elseif !is_in_fexpr(x, CSTParser.defines_function)
+        elseif !is_in_fexpr(x, CSTParser.defines_function) && !isempty(init_path)
             seterror!(x, MissingFile)
         end
     end


### PR DESCRIPTION
This makes the linter a bit more conservative (it should only complain if we can actually find a path, not when we give up on finding one) and fixes https://github.com/julia-vscode/julia-vscode/issues/1608.