### PR TITLE
more at-nospecialize handling

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -472,7 +472,7 @@ function check_farg_unused(x::EXPR)
 end
 
 function unwrap_nospecialize(x)
-    is_nospecialize(x) || return x
+    is_nospecialize_call(x) || return x
     len = length(x)
     return if len == 2
         x[2] # enclosed form, e.g. `@nospecialize(a = 0)`
@@ -481,13 +481,11 @@ function unwrap_nospecialize(x)
     end
 end
 
-function is_nospecialize(x)
+function is_nospecialize_call(x)
     return is_macro_call(x) &&
         length(x) > 1 &&
         is_macroname(x[1]) &&
-        length(x[1]) == 2 &&
-        isidentifier(x[1][2]) &&
-        valofid(x[1][2]) == "nospecialize"
+        is_nospecialize(x[1])
 end
 
 """

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -139,13 +139,7 @@ function func_nargs(x::EXPR)
     minargs, maxargs, kws, kwsplat = 0, 0, Symbol[], false
     sig = rem_wheres_decls(CSTParser.get_sig(x))
     for i = 2:length(sig)
-        arg = sig[i]
-        if is_macro_call(arg) && length(arg) > 1 &&
-            is_macroname(arg[1]) && length(arg[1]) == 2 && isidentifier(arg[1][2]) && valofid(arg[1][2]) == "nospecialize"
-            if length(arg) == 2
-                arg = arg[2]
-            end
-        end
+        arg = unwrap_nospecialize(sig[i])
         if ispunctuation(arg)
             # skip
         elseif is_parameters(arg)
@@ -461,7 +455,7 @@ function check_farg_unused(x::EXPR)
         if is_call(sig)
             for i = 2:length(sig)
                 if hasbinding(sig[i])
-                    arg = sig[i]
+                    arg = unwrap_nospecialize(sig[i])
                 elseif is_kwarg(sig[i]) && hasbinding(sig[i][1])
                     arg = sig[i][1]
                 else
@@ -477,8 +471,24 @@ function check_farg_unused(x::EXPR)
     end
 end
 
+function unwrap_nospecialize(x)
+    is_nospecialize(x) || return x
+    len = length(x)
+    return if len == 2
+        x[2] # unwrapped form
+    elseif len == 4
+        x[3] # wrapped form
+    end
+end
 
-
+function is_nospecialize(x)
+    return is_macro_call(x) &&
+        length(x) > 1 &&
+        is_macroname(x[1]) &&
+        length(x[1]) == 2 &&
+        isidentifier(x[1][2]) &&
+        valofid(x[1][2]) == "nospecialize"
+end
 
 """
 collect_hints(x::EXPR, server, missingrefs = :all, isquoted = false, errs = Tuple{Int,EXPR}[], pos = 0)

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -475,9 +475,9 @@ function unwrap_nospecialize(x)
     is_nospecialize(x) || return x
     len = length(x)
     return if len == 2
-        x[2] # unwrapped form
+        x[2] # enclosed form, e.g. `@nospecialize(a = 0)`
     elseif len == 4
-        x[3] # wrapped form
+        x[3] # open call form, e.g. `@nospecialize args...`
     end
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -56,7 +56,7 @@ function handle_macro(x::EXPR, state)
             if length(x) == 2 && isidentifier(x[2])
                 mark_binding!(x[2])
             end
-        elseif length(x[1]) == 2 && isidentifier(x[1][2]) && valofid(x[1][2]) == "nospecialize"
+        elseif is_nospecialize(x[1])
             for i = 2:length(x)
                 if !ispunctuation(x[i])
                     if bindingof(x[i]) !== nothing
@@ -99,6 +99,12 @@ function handle_macro(x::EXPR, state)
         mark_binding!(x[3])
         setref!(x[3], bindingof(x[3]))
     end
+end
+
+function is_nospecialize(x)
+    return length(x) == 2 &&
+        isidentifier(x[2]) &&
+        valofid(x[2]) == "nospecialize"
 end
 
 function _rem_ref(x::EXPR)
@@ -180,7 +186,7 @@ end
 interpret_eval(x::EXPR, state)
 
 Naive attempt to interpret `x` as though it has been eval'ed. Lifts
-any bindings made within the scope of `x` to the toplevel and replaces 
+any bindings made within the scope of `x` to the toplevel and replaces
 (some) interpolated binding names with the value where possible.
 """
 function interpret_eval(x::EXPR, state)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,13 +78,13 @@ f
 """)  == [false, true, true]
 
         @test check_resolved("""
-function f(a) 
+function f(a)
 end
 """)  == [true, true]
 
         @test check_resolved("""
 f, a
-function f(a) 
+function f(a)
     a
 end
 f, a
@@ -325,7 +325,7 @@ f(arg) = arg
         struct Graph
             children:: T
         end
-        
+
         function test()
             g = Graph()
             f = g.children
@@ -357,7 +357,7 @@ f(arg) = arg
         end
 
         @test check_resolved("""
-    @enum E a b 
+    @enum E a b
     E
     a
     b
@@ -836,6 +836,10 @@ f(arg) = arg
             StaticLint.check_farg_unused(cst[1])
             @test StaticLint.errorof(CSTParser.get_sig(cst[1])[3]) === nothing
         end
+        let cst = parse_and_pass("func(@nospecialize(arg)) = arg")
+            StaticLint.check_farg_unused(cst[1])
+            @test cst[1].args[1].args[3].meta.error === nothing
+        end
     end
 
     @testset "check redefinition of const" begin
@@ -968,7 +972,7 @@ f(arg) = arg
 
         @testset "interpret @eval" begin # e.g. `using StaticLint: StaticLint`
             let cst = parse_and_pass("""
-        let 
+        let
             @eval adf = 1
         end
         """)
@@ -976,7 +980,7 @@ f(arg) = arg
                 @test !StaticLint.scopehasbinding(scopeof(cst[1]), "adf")
             end
             let cst = parse_and_pass("""
-        let 
+        let
             @eval a,d,f = 1,2,3
         end
         """)
@@ -988,7 +992,7 @@ f(arg) = arg
                 @test !StaticLint.scopehasbinding(scopeof(cst[1]), "f")
             end
             let cst = parse_and_pass("""
-        let 
+        let
             @eval a = 1
             @eval d = 2
             @eval f = 3


### PR DESCRIPTION
follows #212; this one handles `@nospecialize(val)` form and fixes false positive unused arg reports