### PR TITLE
add a nothing-check in check_farg_unused

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -468,8 +468,10 @@ function check_farg_unused(x::EXPR)
                     continue
                 end
                 b = bindingof(arg)
-                if (isempty(b.refs) || (length(b.refs) == 1 && first(b.refs) == b.name)) &&
-                    b.next === nothing
+                if b === nothing || (
+                       (isempty(b.refs) || (length(b.refs) == 1 && first(b.refs) == b.name)) &&
+                       b.next === nothing
+                   )
                     seterror!(arg, UnusedFunctionArgument)
                 end
             end


### PR DESCRIPTION
Fixes an error on Azure:
```
ErrorException: type Nothing has no field refs 
   at getproperty(::Nothing, ::Symbol) (Base.jl33)
   at check_farg_unused(::CSTParser.EXPR) (./julialang.language-julia-insider-1.0.10/scripts/packages/StaticLint/src/linting/checks.jl471)
   at check_all(::CSTParser.EXPR, ::StaticLint.LintOptions, ::LanguageServerInstance) (./julialang.language-julia-insider-1.0.10/scripts/packages/StaticLint/src/linting/checks.jl93)
   at check_all(::CSTParser.EXPR, ::StaticLint.LintOptions, ::LanguageServerInstance) (./julialang.language-julia-insider-1.0.10/scripts/packages/StaticLint/src/linting/checks.jl101)
   at lint!(::LanguageServer.Document, ::LanguageServerInstance) (./julialang.language-julia-insider-1.0.10/scripts/packages/LanguageServer/src/staticlint.jl58)
   at parse_all(::LanguageServer.Document, ::LanguageServerInstance) (./julialang.language-julia-insider-1.0.10/scripts/packages/LanguageServer/src/requests/textdocument.jl238)
   at load_folder(::String, ::LanguageServerInstance) (./julialang.language-julia-insider-1.0.10/scripts/packages/LanguageServer/src/requests/init.jl111)
   at initialized_notification(::LanguageServer.InitializedParams, ::LanguageServerInstance, ::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint,Base.PipeEndpoint}) (./julialang.language-julia-insider-1.0.10/scripts/packages/LanguageServer/src/requests/init.jl175)
   at (::LanguageServer.var"#112#145"{LanguageServerInstance})(::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint,Base.PipeEndpoint}, ::LanguageServer.InitializedParams) (./julialang.language-julia-insider-1.0.10/scripts/packages/LanguageServer/src/languageserverinstance.jl285)
   at dispatch_msg(::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint,Base.PipeEndpoint}, ::JSONRPC.MsgDispatcher, ::Dict{String,Any}) (./julialang.language-julia-insider-1.0.10/scripts/packages/JSONRPC/src/typed.jl66)
   at run(::LanguageServerInstance) (./julialang.language-julia-insider-1.0.10/scripts/packages/LanguageServer/src/languageserverinstance.jl310)
   at top-level scope (./julialang.language-julia-insider-1.0.10/scripts/languageserver/main.jl59)
   at include(::Function, ::Module, ::String) (Base.jl380)
   at include(::Module, ::String) (Base.jl368)
   at exec_options(::Base.JLOptions) (client.jl296)
   at _start() (client.jl506)
```