### PR TITLE
add a nothing-check in isglobal

### DIFF
--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -370,7 +370,7 @@ function hoist_prev_binding(b, name, scope, state)
 end
 
 isglobal(name, scope) = false
-isglobal(name::String, scope) = scopehasbinding(scope, "#globals") && name in scope.names["#globals"].refs
+isglobal(name::String, scope) = scope !== nothing && scopehasbinding(scope, "#globals") && name in scope.names["#globals"].refs
 
 function mark_globals(x::EXPR, state)
     if typof(x) === CSTParser.Global

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -7,7 +7,8 @@ function resolve_import(x, state::State)
         root = par = getsymbolserver(state.server)
         while i <= n
             arg = x[i]
-            if is_id_or_macroname(arg)
+            if arg === nothing
+            elseif is_id_or_macroname(arg)
                 if refof(arg) !== nothing
                     par = refof(arg)
                 else


### PR DESCRIPTION
Fixes
```
MethodError: no method matching scopehasbinding(::Nothing, ::String)
Closest candidates are:
  scopehasbinding(!Matched::StaticLint.Scope, ::String) at c:\Users\...\.vscode\extensions\julialang.language-julia-1.0.10\scripts\packages\StaticLint\src\scope.jl:57 
```

The second commit should fix
```
MethodError: no method matching get_named_toplevel_module(::StaticLint.Scope, ::Nothing)
Closest candidates are:
  get_named_toplevel_module(::StaticLint.Scope, !Matched::String) at /Users/.../.vscode/extensions/julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/imports.jl:90 
MethodError:
   at _get_field(::Dict{Symbol,SymbolServer.ModuleStore}, ::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/imports.jl101)
   at resolve_import(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/imports.jl14)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl59)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at traverse(::CSTParser.EXPR, ::StaticLint.Toplevel{LanguageServer.Document}) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl129)
   at (::StaticLint.Toplevel{LanguageServer.Document})(::CSTParser.EXPR) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/StaticLint.jl71)
   at scopepass(::LanguageServer.Document, ::LanguageServer.Document) (./julialang.language-julia-1.0.10/scripts/packages/StaticLint/src/server.jl45)
   at parse_all(::LanguageServer.Document, ::LanguageServerInstance) (./julialang.language-julia-1.0.10/scripts/packages/LanguageServer/src/requests/textdocument.jl237)
   at workspace_didChangeWatchedFiles_notification(::LanguageServer.DidChangeWatchedFilesParams, ::LanguageServerInstance, ::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint,Base.PipeEndpoint}) (./julialang.language-julia-1.0.10/scripts/packages/LanguageServer/src/requests/workspace.jl46)
   at (::LanguageServer.var"#125#158"{LanguageServerInstance})(::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint,Base.PipeEndpoint}, ::LanguageServer.DidChangeWatchedFilesParams) (./julialang.language-julia-1.0.10/scripts/packages/LanguageServer/src/languageserverinstance.jl298)
   at dispatch_msg(::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint,Base.PipeEndpoint}, ::JSONRPC.MsgDispatcher, ::Dict{String,Any}) (./julialang.language-julia-1.0.10/scripts/packages/JSONRPC/src/typed.jl66)
   at run(::LanguageServerInstance) (./julialang.language-julia-1.0.10/scripts/packages/LanguageServer/src/languageserverinstance.jl310)
   at top-level scope (./julialang.language-julia-1.0.10/scripts/languageserver/main.jl59)
   at include(::Function, ::Module, ::String) (Base.jl380)
   at include(::Module, ::String) (Base.jl368)
   at exec_options(::Base.JLOptions) (client.jl296)
   at _start() (client.jl506)

```