### PR TITLE
infer binding types by use

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -103,8 +103,12 @@ function (state::Delayed)(x::EXPR)
     resolve_ref(x, state)
 
     traverse(x, state)
-
-    state.scope != s0 && (state.scope = s0)
+    if state.scope != s0
+        for (k,b) in state.scope.names
+            infer_type_by_use(b, state.server)
+        end
+        (state.scope = s0)
+    end
     return state.scope
 end
 

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -107,7 +107,7 @@ function (state::Delayed)(x::EXPR)
         for (k,b) in state.scope.names
             infer_type_by_use(b, state.server)
         end
-        (state.scope = s0)
+        state.scope = s0
     end
     return state.scope
 end

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -883,7 +883,7 @@ end
 function check_kw_is_assigned(x::EXPR)
     if CSTParser.defines_function(x)
         sig = CSTParser.get_sig(x)
-        if length(sig.args) > 1 && headof(sig.args[2]) === :parameters
+        if sig.args !== nothing && length(sig.args) > 1 && headof(sig.args[2]) === :parameters
             params = sig.args[2]
             for a in params.args
                 if !(headof(a) == :kw || CSTParser.ismacrocall(a))

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -560,6 +560,11 @@ function should_mark_missing_getfield_ref(x, server)
             if lhsref.type isa SymbolServer.DataTypeStore && !(isempty(lhsref.type.fieldnames) || isunionfaketype(lhsref.type.name) || has_getproperty_method(lhsref.type, server))
                 return true
             elseif lhsref.type isa Binding && lhsref.type.val isa EXPR && CSTParser.defines_struct(lhsref.type.val) && !has_getproperty_method(lhsref.type)
+                # We may have infered the lhs type after the semantic pass that was resolving references. Copied from `resolve_getfield(x::EXPR, parent_type::EXPR, state::State)::Bool`.
+                if scopehasbinding(scopeof(lhsref.type.val), valof(x))
+                    setref!(x, scopeof(lhsref.type.val).names[valof(x)])
+                    return false
+                end
                 return true
             end
         end

--- a/src/server.jl
+++ b/src/server.jl
@@ -46,6 +46,9 @@ function semantic_pass(file, target=nothing)
     for x in state.delayed
         if hasscope(x)
             traverse(x, Delayed(scopeof(x), server))
+            for (k,b) in scopeof(x).names
+                infer_type_by_use(b, state.server)
+            end
         else
             ds = retrieve_delayed_scope(x)
             traverse(x, Delayed(ds, server))

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -61,7 +61,7 @@ end
 
 # Work out what type a bound variable has by functions that are called on it.
 function infer_type_by_use(b::Binding, server)
-    # b.type !== nothing && return # b already has a type
+    b.type !== nothing && return # b already has a type
     possibletypes = []
     visitedmethods = []
     for ref in b.refs

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -58,3 +58,117 @@ function infer_type(binding::Binding, scope, state)
         end
     end
 end
+
+# Work out what type a bound variable has by functions that are called on it.
+function infer_type_by_use(b::Binding, server)
+    # b.type !== nothing && return # b already has a type
+    possibletypes = []
+    visitedmethods = []
+    for ref in b.refs
+        new_possibles = []
+        ref isa EXPR || continue # skip non-EXPR (i.e. used for handling of globals)
+        check_ref_against_calls(ref, visitedmethods, new_possibles, server)
+
+        if isempty(possibletypes)
+            possibletypes = new_possibles
+        elseif !isempty(new_possibles)
+            possibletypes = intersect(possibletypes, new_possibles)
+            if isempty(possibletypes)
+                return
+            end
+        end
+    end
+    # Only do something if we're left with a singleton set at the end.
+    if length(possibletypes) == 1
+        type = first(possibletypes)
+    
+        if type isa Binding
+            b.type = type
+        elseif type isa SymbolServer.DataTypeStore
+            b.type = type
+        elseif type isa SymbolServer.VarRef
+            b.type = SymbolServer._lookup(type, getsymbolserver(server)) # could be nothing
+        elseif type isa SymbolServer.FakeTypeName && isempty(type.parameters)
+            b.type = SymbolServer._lookup(type.name, getsymbolserver(server)) # could be nothing
+        end
+    end
+end
+
+function check_ref_against_calls(x, visitedmethods, new_possibles, server)
+    if is_arg_of_resolved_call(x)
+        sig = parentof(x)
+        # x is argument of function call (func) and we know what that function is
+        if CSTParser.isidentifier(sig.args[1])
+            func = refof(sig.args[1])
+        else
+            func = refof(sig.args[1].args[2].args[1])
+        end
+        # make sure we've got the last binding for func
+        if func isa Binding
+            func = get_last_method(func, server)
+        end
+        # what slot does ref sit in?
+        argi = get_arg_position_in_call(sig, x)
+        tls = retrieve_toplevel_scope(x)
+        while (func isa Binding && func.type == CoreTypes.Function) || func isa SymbolServer.SymStore
+            !(func in visitedmethods) ? push!(visitedmethods, func) : return # check whether we've been here before
+            if func isa Binding
+                get_arg_type_at_position(func, argi, new_possibles)
+                func = func.prev
+            else
+                tls === nothing && return
+                iterate_over_ss_methods(func, tls, server, m->(get_arg_type_at_position(m, argi, new_possibles);false))
+                return
+            end
+        end
+    end
+end
+
+function is_arg_of_resolved_call(x::EXPR) 
+    parentof(x) isa EXPR && headof(parentof(x)) === :call && # check we're in a call signature
+    (caller = parentof(x).args[1]) !== x && # and that x is not the caller
+    (hasref(caller) || (is_getfield(caller) && headof(caller.args[2]) === :quotenode && hasref(caller.args[2].args[1])))
+end
+
+function get_arg_position_in_call(sig::EXPR, arg)
+    for i in 1:length(sig.args)
+        sig.args[i] == arg && return i
+    end
+end
+
+function get_arg_type_at_position(b::Binding, argi, types)
+    if b.val isa EXPR
+        sig = CSTParser.get_sig(b.val)
+        if sig !== nothing && 
+            sig.args !== nothing && argi <= length(sig.args) &&
+            hasbinding(sig.args[argi]) &&
+            (argb = bindingof(sig.args[argi]); argb isa Binding && argb.type !== nothing) && 
+            !(argb.type in types)
+            push!(types, argb.type)
+            return
+        end
+    elseif b.val isa SymbolServer.DataTypeStore || b.val isa SymbolServer.FunctionStore
+        for m in b.val.methods
+            get_arg_type_at_position(m, argi, types)
+        end
+    end
+    return
+end
+
+function get_arg_type_at_position(m::SymbolServer.MethodStore, argi, types)
+    if length(m.sig) >= argi && m.sig[argi][2] != SymbolServer.VarRef(SymbolServer.VarRef(nothing, :Core), :Any) && !(m.sig[argi][2] in types)
+        push!(types, m.sig[argi][2])
+    end
+end
+
+function get_last_method(b::Binding, server, visited_bindings = Binding[])
+    if b.next === nothing || b == b.next || !(b.next isa Binding) || b in visited_bindings
+        return b
+    end
+    push!(visited_bindings, b)
+    if b.type == b.next.type == CoreTypes.Function
+        return get_last_method(b.next, server, visited_bindings)
+    else
+        return b
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1460,4 +1460,12 @@ f(arg) = arg
         end""")
         @test bindingof(cst.args[3].args[1].args[2]).type !== nothing
 end
+@testset "check for unassigned keyword arguments" begin
+    cst = parse_and_pass("""
+    function func3(x; y) end
+    func3(2; y=3)
+    """)
+    @test StaticLint.haserror(cst.args[1].args[1].args[2].args[1])
+    @test StaticLint.haserror(cst.args[2])
+end
 end


### PR DESCRIPTION
Some extra type inference. 
Finds all the instances where a binding is used as the argument to a function call and then finds the intersect of possible types for that argment position. Only works in fairly simple cases (e.g. no handling for abstract types or unions of types).

Restricted to not run on the top-level scope.