### PR TITLE
add eval method that isn't Core.eval

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1462,11 +1462,12 @@ f(arg) = arg
     end
     @testset "check for unassigned keyword arguments" begin
         cst = parse_and_pass("""
-    function func3(x; y) end
-    func3(2; y=3)
-    """)
-    @test StaticLint.haserror(cst.args[1].args[1].args[2].args[1])
-    @test StaticLint.haserror(cst.args[2])
+        function func3(x; y) end
+        func3(2; y=3)
+        """)
+        @test StaticLint.haserror(cst.args[1].args[1].args[2].args[1])
+        @test StaticLint.haserror(cst.args[2])
+    end
 end
 
 @testset "add eval method to modules/toplevel scope" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1468,4 +1468,20 @@ end
     @test StaticLint.haserror(cst.args[1].args[1].args[2].args[1])
     @test StaticLint.haserror(cst.args[2])
 end
+
+@testset "add eval method to modules/toplevel scope" begin
+    cst = parse_and_pass("""
+    module M
+    expr = :(a + b)
+    eval(expr)
+    end
+    """)
+    @test !StaticLint.haserror(cst.args[1].args[3].args[2])
+
+    cst = parse_and_pass("""
+    expr = :(a + b)
+    eval(expr)
+    """)
+    @test !StaticLint.haserror(cst.args[2])
+end
 end


### PR DESCRIPTION
Adds a binding for `eval` on entry to the top-level or a module scope. Are there other bindings that are automatically included in modules (other than themselves)?