### PR TITLE
add resolve only pass

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1"
-CSTParser = "3"
+CSTParser = "3.1"
 SymbolServer = "5.1.1"
 
 [targets]

--- a/src/server.jl
+++ b/src/server.jl
@@ -38,23 +38,6 @@ end
 getsymbolserver(server::FileServer) = server.symbolserver
 getsymbolextendeds(server::FileServer) = server.symbol_extends
 
-function semantic_pass(file, target=nothing)
-    server = file.server
-    setscope!(getcst(file), Scope(nothing, getcst(file), Dict(), Dict{Symbol,Any}(:Base => getsymbolserver(server)[:Base], :Core => getsymbolserver(server)[:Core]), nothing))
-    state = Toplevel(file, target, [getpath(file)], scopeof(getcst(file)), EXPR[], server)
-    state(getcst(file))
-    for x in state.delayed
-        if hasscope(x)
-            traverse(x, Delayed(scopeof(x), server))
-            for (k, b) in scopeof(x).names
-                infer_type_by_use(b, state.server)
-            end
-        else
-            ds = retrieve_delayed_scope(x)
-            traverse(x, Delayed(ds, server))
-        end
-    end
-end
 
 getpath(file::File) = file.path
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1476,3 +1476,17 @@ end
     """)
     @test !StaticLint.haserror(cst.args[2])
 end
+
+@testset "reparse" begin
+    cst = parse_and_pass("""
+    x = 1
+    function f(arg)
+        x
+    end
+    """)
+    @test StaticLint.hasref(cst.args[2].args[2].args[1])
+    StaticLint.clear_meta(cst[2])
+    @test !StaticLint.hasref(cst.args[2].args[2].args[1])
+    StaticLint.semantic_pass(server.files[""], CSTParser.EXPR[cst[2]])
+    @test StaticLint.hasref(cst.args[2].args[2].args[1])
+end


### PR DESCRIPTION
Adds a new option for `semantic_pass` whereby only 'target' expressions get the full treatment (i.e. build new scopes, add bindings etc) for the rest we only resolve references. The logic isn't fully worked out but the idea is that we'd only run everything on the toplevel scope and those parts of the tree (delayed scope - e.g. functions) that are new - for the rest we only need to ensure that any new bindings that have been added to the toplevel scope are resolved.