### PR TITLE
Remove between Binding linkages

### DIFF
--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -3,10 +3,8 @@ mutable struct Binding
     val::Union{Binding,EXPR,SymbolServer.SymStore,Nothing}
     type::Union{Binding,EXPR,SymbolServer.SymStore,Nothing}
     refs::Vector{Any}
-    prev::Union{Binding,SymbolServer.SymStore,Nothing}
-    next::Union{Binding,SymbolServer.SymStore,Nothing}
 end
-Binding(x::EXPR) = Binding(CSTParser.get_name(x), x, nothing, [], nothing, nothing)
+Binding(x::EXPR) = Binding(CSTParser.get_name(x), x, nothing, [])
 
 function Base.show(io::IO, b::Binding)
     printstyled(io, " Binding(", Expr(b.name),
@@ -48,9 +46,6 @@ function mark_bindings!(x::EXPR, state)
             name = CSTParser.get_name(x)
             mark_binding!(x)
             mark_sig_args!(x.args[1])
-            if isidentifier(name)
-                setref!(name, bindingof(x))
-            end
         elseif CSTParser.iscurly(x.args[1])
             mark_typealias_bindings!(x)
         elseif !is_getfield(x.args[1])
@@ -64,45 +59,30 @@ function mark_bindings!(x::EXPR, state)
         end
     elseif headof(x) === :for
         markiterbinding!(x.args[2])
-    elseif headof(x) === :generator 
+    elseif headof(x) === :generator || headof(x) === :filter
         for i = 2:length(x.args)
             markiterbinding!(x.args[i])
         end
-    elseif headof(x) === :filter
-        for i = 2:length(x.args)
-            markiterbinding!(x.args[i])
-        end
-    # elseif headof(x) === CSTParser.Flatten && length(x.args) === 1 && length(x[1]) >= 3 && length(x[1][1]) >= 3
-    #     for i = 3:length(x[1][1])
-    #         ispunctuation(x[1][1][i]) && continue
-    #         markiterbinding!(x[1][1][i])
-    #     end
-    #     for i = 3:length(x[1])
-    #         ispunctuation(x[1][i]) && continue
-    #         markiterbinding!(x[1][i])
-    #     end
     elseif headof(x) === :do
-        if istuple(x.args[2])
-            for i in 1:length(x.args[2].args)
-                mark_binding!(x.args[2].args[i])
-            end
+        for i in 1:length(x.args[2].args)
+            mark_binding!(x.args[2].args[i])
         end
     elseif headof(x) === :function || headof(x) === :macro
         name = CSTParser.get_name(x)
-        x.meta.binding = Binding(name, x, CoreTypes.Function, [], nothing, nothing)
-        if isidentifier(name)
+        x.meta.binding = Binding(name, x, CoreTypes.Function, [])
+        if isidentifier(name) && headof(x) === :macro
             setref!(name, bindingof(x))
         end
         mark_sig_args!(CSTParser.get_sig(x))
     elseif CSTParser.defines_module(x)
-        x.meta.binding = Binding(x.args[2], x, CoreTypes.Module, [], nothing, nothing)
+        x.meta.binding = Binding(x.args[2], x, CoreTypes.Module, [])
         setref!(x.args[2], bindingof(x))
     elseif headof(x) === :try && isidentifier(x.args[2])
         mark_binding!(x.args[2])
         setref!(x.args[2], bindingof(x.args[2]))
     elseif CSTParser.defines_datatype(x)
         name = CSTParser.get_name(x)
-        x.meta.binding = Binding(name, x, CoreTypes.DataType, [], nothing, nothing)
+        x.meta.binding = Binding(name, x, CoreTypes.DataType, [])
         kwdef = parentof(x) isa EXPR && _points_to_Base_macro(parentof(x).args[1], Symbol("@kwdef"), state)
         if isidentifier(name)
             setref!(name, bindingof(x))
@@ -144,7 +124,7 @@ function mark_binding!(x::EXPR, val=x)
         if !hasmeta(x)
             x.meta = Meta()
         end
-        x.meta.binding = Binding(CSTParser.get_name(x), val, nothing, [], nothing, nothing)
+        x.meta.binding = Binding(CSTParser.get_name(x), val, nothing, [])
     end
     return x
 end
@@ -253,12 +233,9 @@ end
 function add_binding(x, state, scope=state.scope)
     if bindingof(x) isa Binding
         b = bindingof(x)
-        b.prev = nothing
-        b.next = nothing
         if isidentifier(b.name)
             name = valofid(b.name)
         elseif CSTParser.ismacroname(b.name) # must be getfield
-            # name = CSTParser.rhs_getfield(b.name)
             name = string(Expr(b.name))
         elseif isoperator(b.name)
             name = string(Expr(b.name))
@@ -276,53 +253,62 @@ function add_binding(x, state, scope=state.scope)
             if isidentifier(mn)
                 setref!(mn, b)
             end
-        else
-            if name_is_getfield(b.name)# && b.type == CoreTypes.Function
-                # Question: should `b.name` include the getfield itself?
-                # Binding name is part of a getfield : `A.name` so is either
-                # 1. Overloading of a function
-                # 2. Setting of a field or property
-                # We only care about 1.
+        elseif defines_function(x)
+            # TODO: Need to do check that we're not in a closure.
+            tls = retrieve_toplevel_or_func_scope(scope)
+            tls === nothing && return @warn "top-level scope not retrieved"
+            if name_is_getfield(b.name)
                 resolve_ref(parentof(parentof(b.name)).args[1], scope, state)
                 lhs_ref = refof_maybe_getfield(parentof(parentof(b.name)).args[1])
-                if lhs_ref === nothing
-                    # We don't know what we're assigning to, do nothing
-                else
-                    if lhs_ref isa SymbolServer.ModuleStore && haskey(lhs_ref.vals, Symbol(name))
-                        # Overloading
-                        tls = retrieve_toplevel_scope(b.val)
-                        tls === nothing && return # Shouldn't happen
-                        if haskey(tls.names, name) && eventually_overloads(tls.names[name], lhs_ref.vals[Symbol(name)], state.server)
-                            # Though we're explicitly naming a function for overloading, it has already been imported to the toplevel scope.
-                            overload_method(tls, b, VarRef(lhs_ref.name, Symbol(name)))
-                            b.prev = tls.names[name]
-                            b.prev.next = b
-                            tls.names[name] = b
-                        elseif isexportedby(name, lhs_ref)
-                            tls.names[name] = b
-                            b.prev = maybe_lookup(lhs_ref[Symbol(name)], state.server)
-                        else
+                if lhs_ref isa SymbolServer.ModuleStore && haskey(lhs_ref.vals, Symbol(name))
+                    # Overloading
+                    if haskey(tls.names, name) && eventually_overloads(tls.names[name], lhs_ref.vals[Symbol(name)], state.server)
+                        # Though we're explicitly naming a function for overloading, it has already been imported to the toplevel scope.
+                        if !hasref(b.name) 
+                            setref!(b.name, tls.names[name]) # Add ref to previous overload
                             overload_method(tls, b, VarRef(lhs_ref.name, Symbol(name)))
                         end
-                    elseif lhs_ref isa Binding && lhs_ref.type == CoreTypes.Module
-                        if hasscope(lhs_ref.val) && haskey(scopeof(lhs_ref.val).names, name)
-                            b.prev = scopeof(lhs_ref.val).names[name]
-                            scopeof(lhs_ref.val).names[name] = b
+                        # Do nothing, get_name(x) will resolve to the root method
+                    elseif isexportedby(name, lhs_ref)
+                        # Name is already available
+                        tls.names[name] = b 
+                        if !hasref(b.name) # Is this an appropriate indicator that we've not marked the overload?
+                            push!(b.refs, maybe_lookup(lhs_ref[Symbol(name)], state.server))
+                            setref!(b.name, b) # we actually set the rhs of the qualified name to point to this binding
                         end
+                    else
+                        # Mark as overloaded so that calls to `M.f()` resolve properly.
+                        overload_method(tls, b, VarRef(lhs_ref.name, Symbol(name))) # Add to overloaded list but not scope.
+                    end
+                elseif lhs_ref isa Binding && lhs_ref.type == CoreTypes.Module
+                    if hasscope(lhs_ref.val) && haskey(scopeof(lhs_ref.val).names, name)
+                        # Don't need to do anything, name will resolve
                     end
                 end
-
-            elseif scopehasbinding(scope, name)
-                b.prev = scope.names[name]
-                scope.names[name] = b
-                b.prev.next = b
             else
-                scope.names[name] = b
+                if scopehasbinding(tls, name)
+                    if tls.names[name] isa Binding && ((tls.names[name].type == CoreTypes.Function || tls.names[name].type == CoreTypes.DataType) || tls.names[name] isa SymbolServer.FunctionStore || tls.names[name] isa SymbolServer.DataTypeStore)
+                        # do nothing name of `x` will resolve to the root method
+                    else
+                        seterror!(x, CannotDefineFuncAlreadyHasValue)
+                    end
+                else
+                    scope.names[name] = b
+                    if !hasref(b.name)
+                        setref!(b.name, b)
+                    end
+                end
+                if CSTParser.defines_struct(scope.expr) && parentof(scope) isa Scope
+                    # hoist binding for inner constructor to parent scope
+                    return add_binding(x, state, parentof(scope))
+                end
             end
-            # hoist binding for inner constructor to parent scope
-            if CSTParser.defines_struct(scope.expr) && CSTParser.defines_function(x) && parentof(scope) isa Scope
-                return add_binding(x, state, parentof(scope))
-            end
+        elseif scopehasbinding(scope, name)
+            # TODO: some checks about rebinding of consts
+            check_const_decl(name, b, scope)
+            scope.names[name] = b
+        else
+            scope.names[name] = b
         end
         infer_type(b, scope, state)
     elseif bindingof(x) isa SymbolServer.SymStore
@@ -338,27 +324,9 @@ eventually_overloads(b, x, server)
 
 
 """
-eventually_overloads(b::Binding, ss::SymbolServer.SymStore, server) = (b.val == ss || b.prev == ss) || (b.prev !== nothing && eventually_overloads(b.prev, ss, server))
-
+eventually_overloads(b::Binding, ss::SymbolServer.SymStore, server) = b.val == ss || (b.refs !== nothing && length(b.refs) > 0 && first(b.refs) == ss)
 eventually_overloads(b::Binding, ss::SymbolServer.VarRef, server) = eventually_overloads(b, maybe_lookup(ss, server), server)
-
 eventually_overloads(b, ss, server) = false
-
-
-
-function hoist_prev_binding(b, name, scope, state)
-    scope === nothing && return
-    if scope.modules !== nothing
-        if scopehasmodule(scope, Symbol(valofid(parentof(parentof(b.name)).args[1]))) # this scope (s1) has a module with matching name
-            mod = getscopemodule(scope, Symbol(valofid(parentof(parentof(b.name)).args[1])))
-            if mod isa SymbolServer.ModuleStore && haskey(mod, Symbol(name))
-                b.prev = maybe_lookup(mod[Symbol(name)], state.server)
-            end
-        end
-        return # We've reached a scope that loads modules, no need to keep searching upwards
-    end
-    return hoist_prev_binding(b, name, parentof(scope), state)
-end
 
 isglobal(name, scope) = false
 isglobal(name::String, scope) = scope !== nothing && scopehasbinding(scope, "#globals") && name in scope.names["#globals"].refs
@@ -366,7 +334,7 @@ isglobal(name::String, scope) = scope !== nothing && scopehasbinding(scope, "#gl
 function mark_globals(x::EXPR, state)
     if headof(x) === :global
         if !scopehasbinding(state.scope, "#globals")
-            state.scope.names["#globals"] = Binding(EXPR(:IDENTIFIER, EXPR[], nothing, 0, 0, "#globals", nothing, nothing), nothing, nothing, [], nothing, nothing)
+            state.scope.names["#globals"] = Binding(EXPR(:IDENTIFIER, EXPR[], nothing, 0, 0, "#globals", nothing, nothing), nothing, nothing, [])
         end
         for i = 2:length(x.args)
             if isidentifier(x.args[i]) && !scopehasbinding(state.scope, valofid(x.args[i]))

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -56,7 +56,7 @@ function _mark_import_arg(arg, par, state, usinged)
             if !hasmeta(arg)
                 arg.meta = Meta()
             end
-            arg.meta.binding = Binding(arg, par, _typeof(par, state), [], nothing, nothing)
+            arg.meta.binding = Binding(arg, par, _typeof(par, state), [])
             setref!(arg, bindingof(arg))
         end
 

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -17,10 +17,11 @@ function overload_method(scope::Scope, b::Binding, vr::SymbolServer.VarRef)
         scope.overloaded = Dict()
     end
     if haskey(scope.overloaded, vr)
-        b.prev = scope.overloaded[vr]
-        b.prev.next = b
+        # TODO: need to check this hasn't already been done
+        push!(scope.overloaded[vr].refs, b.val)
+    else
+        scope.overloaded[vr] = b
     end
-    scope.overloaded[vr] = b
 end
 
 """
@@ -150,5 +151,5 @@ function add_eval_method(x, state)
         Symbol("top-level")
     end
     meth = SymbolServer.MethodStore(:eval, mod, "", 0, [:expr => SymbolServer.FakeTypeName(SymbolServer.VarRef(SymbolServer.VarRef(nothing, :Core), :Any), [])], [], Any)
-    state.scope.names["eval"] = Binding(x, SymbolServer.FunctionStore(SymbolServer.VarRef(nothing, :nothing), SymbolServer.MethodStore[meth],"", SymbolServer.VarRef(nothing, :nothing), false), getsymbolserver(state.server)[:Core][:DataType], [], nothing, nothing)
+    state.scope.names["eval"] = Binding(x, SymbolServer.FunctionStore(SymbolServer.VarRef(nothing, :nothing), SymbolServer.MethodStore[meth],"", SymbolServer.VarRef(nothing, :nothing), false), getsymbolserver(state.server)[:Core][:DataType], [])
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -1,3 +1,10 @@
+#=
+Project trees are usually made up of multiple files. An AbstractServer holds the AbstractFiles that represent this tree. FileServer is the basic implementation and assumes files are available and readable from disc. (LanguageServer illustrates another implementaiton). The accompanying functions summarised below are required for making an alternative implementation. 
+
+Interface spec.
+AbstractServer :-> (has/canload/load/set/get)file, getsymbolserver, getsymbolextends
+AbstractFile :-> (get/set)path, (get/set)root, (get/set)cst, semantic_pass, (get/set)server
+=#
 abstract type AbstractServer end
 abstract type AbstractFile end
 
@@ -16,10 +23,6 @@ mutable struct FileServer <: AbstractServer
     symbol_extends::Dict{SymbolServer.VarRef,Vector{SymbolServer.VarRef}}
 end
 FileServer() = FileServer(Dict{String,File}(), Set{File}(), deepcopy(SymbolServer.stdlibs), SymbolServer.collect_extended_methods(SymbolServer.stdlibs))
-
-# Interface spec.
-# AbstractServer :-> (has/canload/load/set/get)file, getsymbolserver, getsymbolextends
-# AbstractFile :-> (get/set)path, (get/set)root, (get/set)cst, semantic_pass, (get/set)server
 
 hasfile(server::FileServer, path::String) = haskey(server.files, path)
 canloadfile(server, path) = isfile(path)
@@ -73,46 +76,3 @@ function Base.display(s::FileServer)
         cnt > 10 && break
     end
 end
-
-"""
-    get_path(x::EXPR)
-
-Usually called on the argument to `include` calls, and attempts to determine
-the path of the file to be included. Has limited support for `joinpath` calls.
-"""
-function get_path(x::EXPR, state)
-    if CSTParser.iscall(x) && length(x.args) == 2
-        parg = x.args[2]
-        if CSTParser.isstringliteral(parg)
-            path = CSTParser.str_value(parg)
-            path = normpath(path)
-            Base.containsnul(path) && throw(SLInvalidPath("Couldn't convert '$x' into a valid path. Got '$path'"))
-            return path
-        elseif CSTParser.ismacrocall(parg) && valof(parg.args[1]) == "@raw_str" && CSTParser.isstringliteral(parg.args[3])
-            path = normpath(CSTParser.str_value(parg.args[3]))
-            Base.containsnul(path) && throw(SLInvalidPath("Couldn't convert '$x' into a valid path. Got '$path'"))
-            return path
-        elseif CSTParser.iscall(parg) && isidentifier(parg.args[1]) && valofid(parg.args[1]) == "joinpath"
-            path_elements = String[]
-
-            for i = 2:length(parg.args)
-                arg = parg[i]
-                if _is_macrocall_to_BaseDIR(arg) # Assumes @__DIR__ points to Base macro.
-                    push!(path_elements, dirname(getpath(state.file)))
-                elseif CSTParser.isstringliteral(arg)
-                    push!(path_elements, string(valofid(arg)))
-                else
-                    return ""
-                end
-            end
-            isempty(path_elements) && return ""
-
-            path = normpath(joinpath(path_elements...))
-            Base.containsnul(path) && throw(SLInvalidPath("Couldn't convert '$x' into a valid path. Got '$path'"))
-            return path
-        end
-    end
-    return ""
-end
-
-_is_macrocall_to_BaseDIR(arg) = headof(arg) === :macrocall && length(arg.args) == 2 && valof(arg.args[1]) == "@__DIR__"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,17 +85,11 @@ function get_root_method(b, server)
     return b
 end
 
-function get_root_method(b::Binding, server, b1=nothing, visited_bindings=Binding[])
-    if b.prev === nothing || b == b.prev || !(b.prev isa Binding) || b in visited_bindings
-        return b
-    end
-    push!(visited_bindings, b)
-    if b.type == b.prev.type == CoreTypes.Function
-        return get_root_method(b.prev, server, b, visited_bindings)
-    elseif b.type == CoreTypes.Function && b.prev.type == CoreTypes.DataType
-        return b.prev
+function get_root_method(b::Binding, server)
+    if b.type == CoreTypes.Function && !isempty(b.refs)
+        first(b.refs)
     else
-        return b
+        b
     end
 end
 
@@ -149,8 +143,6 @@ end
 #     return rets, false
 # end
 
-last_method(b::Binding, visited=Binding[]) = b.next isa Binding && b.next.type === CoreTypes.Function && !(b in visited) ? (push!(visited, b);last_method(b.next, visited)) : b
-
 function find_exported_names(x::EXPR)
     exported_vars = EXPR[]
     for i in 1:length(x.args[3].args)
@@ -188,7 +180,7 @@ isexportedby(x::EXPR, m::SymbolServer.ModuleStore) = isexportedby(valof(x), m)
 isexportedby(k, m::SymbolServer.ModuleStore) = false
 
 function retrieve_toplevel_scope(x::EXPR)
-    if scopeof(x) !== nothing && (CSTParser.defines_module(x) || headof(x) === :file)
+    if scopeof(x) !== nothing && is_toplevel_scope(x)
         return scopeof(x)
     elseif parentof(x) isa EXPR
         return retrieve_toplevel_scope(parentof(x))
@@ -197,8 +189,11 @@ function retrieve_toplevel_scope(x::EXPR)
         return nothing
     end
 end
-retrieve_toplevel_scope(s::Scope) = (CSTParser.defines_module(s.expr) || headof(s.expr) === :file || !(parentof(s) isa Scope)) ? s : retrieve_toplevel_scope(parentof(s))
+retrieve_toplevel_scope(s::Scope) = (is_toplevel_scope(s) || !(parentof(s) isa Scope)) ? s : retrieve_toplevel_scope(parentof(s))
+retrieve_toplevel_or_func_scope(s::Scope) = (is_toplevel_scope(s) || defines_function(s.expr) || !(parentof(s) isa Scope)) ? s : retrieve_toplevel_or_func_scope(parentof(s))
 
+is_toplevel_scope(s::Scope) = is_toplevel_scope(s.expr)
+is_toplevel_scope(x::EXPR) = CSTParser.defines_module(x) || headof(x) === :file
 
 # b::SymbolServer.FunctionStore or DataTypeStore
 # tls is a top-level Scope (expected to contain loaded modules)
@@ -296,3 +291,8 @@ function issigoffuncdecl(x::EXPR, p::EXPR)
     end
 end
 issigoffuncdecl(x::EXPR, p) = false
+
+function is_nameof_func(name)
+    f = get_parent_fexpr(name, CSTParser.defines_function)
+    f !== nothing && CSTParser.get_name(f) == name
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -174,6 +174,9 @@ function _is_in_basedir(path::String)
     return ""
 end
 
+_is_macrocall_to_BaseDIR(arg) = headof(arg) === :macrocall && length(arg.args) == 2 && valof(arg.args[1]) == "@__DIR__"
+
+
 isexportedby(k::Symbol, m::SymbolServer.ModuleStore) = haskey(m, k) && k in m.exportednames
 isexportedby(k::String, m::SymbolServer.ModuleStore) = isexportedby(Symbol(k), m)
 isexportedby(x::EXPR, m::SymbolServer.ModuleStore) = isexportedby(valof(x), m)


### PR DESCRIPTION
Removes the `prev` and `next` field from `Binding` and replaces them with an approach where only the initial binding for a function/datatype is used - all subsequent methods are stored within that initial binding (e.g. a pseudo method table).  Intended to solve stackoverflow errors when iterating through function methods. 

This is ready - bugs will follow but should be relatively easy to squash and _may_ solve one of our most persistent bugs. Interface change so requires ver bump