### PR TITLE
add infrastructure for file-specific environments

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -65,9 +65,9 @@ bindingof(m::Meta) = m.binding
 
 Holds a representation of an environment cached by SymbolServer. 
 """
-struct ExternalEnv
+mutable struct ExternalEnv
     symbols::SymbolServer.EnvStore
-    extended_methods::Dict
+    extended_methods::Dict{SymbolServer.VarRef,Vector{SymbolServer.VarRef}}
     project::Vector{Symbol}
 end
 

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -167,7 +167,7 @@ Performs a semantic pass across a project from the entry point `file`. A first p
 """
 function semantic_pass(file, modified_expr=nothing)
     server = file.server
-    env = get_env(file, server)
+    env = getenv(file, server)
     setscope!(getcst(file), Scope(nothing, getcst(file), Dict(), Dict{Symbol,Any}(:Base => env.symbols[:Base], :Core => env.symbols[:Core]), nothing))
     state = Toplevel(file, [getpath(file)], scopeof(getcst(file)), modified_expr === nothing, modified_expr, EXPR[], EXPR[], env, server)
     state(getcst(file))

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -68,7 +68,7 @@ Holds a representation of an environment cached by SymbolServer.
 mutable struct ExternalEnv
     symbols::SymbolServer.EnvStore
     extended_methods::Dict{SymbolServer.VarRef,Vector{SymbolServer.VarRef}}
-    project::Vector{Symbol}
+    project_deps::Vector{Symbol}
 end
 
 abstract type State end

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -289,7 +289,7 @@ function add_binding(x, state, scope=state.scope)
                 lhs_ref = refof_maybe_getfield(parentof(parentof(b.name)).args[1])
                 if lhs_ref isa SymbolServer.ModuleStore && haskey(lhs_ref.vals, Symbol(name))
                     # Overloading
-                    if haskey(tls.names, name) && eventually_overloads(tls.names[name], lhs_ref.vals[Symbol(name)], state.server)
+                    if haskey(tls.names, name) && eventually_overloads(tls.names[name], lhs_ref.vals[Symbol(name)], state)
                         # Though we're explicitly naming a function for overloading, it has already been imported to the toplevel scope.
                         if !hasref(b.name) 
                             setref!(b.name, tls.names[name]) # Add ref to previous overload
@@ -300,7 +300,7 @@ function add_binding(x, state, scope=state.scope)
                         # Name is already available
                         tls.names[name] = b 
                         if !hasref(b.name) # Is this an appropriate indicator that we've not marked the overload?
-                            push!(b.refs, maybe_lookup(lhs_ref[Symbol(name)], state.server))
+                            push!(b.refs, maybe_lookup(lhs_ref[Symbol(name)], state))
                             setref!(b.name, b) # we actually set the rhs of the qualified name to point to this binding
                         end
                     else
@@ -347,13 +347,13 @@ name_is_getfield(x) = parentof(x) isa EXPR && parentof(parentof(x)) isa EXPR && 
 
 
 """
-eventually_overloads(b, x, server)
+eventually_overloads(b, x, state)
 
 
 """
-eventually_overloads(b::Binding, ss::SymbolServer.SymStore, server) = b.val == ss || (b.refs !== nothing && length(b.refs) > 0 && first(b.refs) == ss)
-eventually_overloads(b::Binding, ss::SymbolServer.VarRef, server) = eventually_overloads(b, maybe_lookup(ss, server), server)
-eventually_overloads(b, ss, server) = false
+eventually_overloads(b::Binding, ss::SymbolServer.SymStore, state) = b.val == ss || (b.refs !== nothing && length(b.refs) > 0 && first(b.refs) == ss)
+eventually_overloads(b::Binding, ss::SymbolServer.VarRef, state) = eventually_overloads(b, maybe_lookup(ss, state), state)
+eventually_overloads(b, ss, state) = false
 
 isglobal(name, scope) = false
 isglobal(name::String, scope) = scope !== nothing && scopehasbinding(scope, "#globals") && name in scope.names["#globals"].refs

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -4,7 +4,7 @@ function resolve_import_block(x::EXPR, state::State, root, usinged, markfinal=tr
         arg = x.args[i]
         if isoperator(arg) && valof(arg) == "."
             # Leading dots. Can only be leading elements.
-            if root == getsymbolserver(state)
+            if root == getsymbols(state)
                 root = state.scope
             elseif root isa Scope && parentof(root) !== nothing
                 root = parentof(root)
@@ -24,7 +24,7 @@ function resolve_import_block(x::EXPR, state::State, root, usinged, markfinal=tr
     end
 end
 
-function resolve_import(x::EXPR, state::State, root=getsymbolserver(state))
+function resolve_import(x::EXPR, state::State, root=getsymbols(state))
     if headof(x) === :using || headof(x) === :import
         usinged = headof(x) === :using
         if length(x.args) > 0 && isoperator(headof(x.args[1])) && valof(headof(x.args[1])) == ":"
@@ -49,7 +49,7 @@ function _mark_import_arg(arg, par, state, usinged)
             push!(par.refs, arg)
         end
         if par isa SymbolServer.VarRef
-            par = SymbolServer._lookup(par, getsymbolserver(state), true)
+            par = SymbolServer._lookup(par, getsymbols(state), true)
             !(par isa SymbolServer.SymStore) && return
         end
         if bindingof(arg) === nothing
@@ -108,7 +108,7 @@ function _get_field(par, arg, state)
         elseif haskey(par, Symbol(arg_str_rep))
             par = par[Symbol(arg_str_rep)]
             if par isa SymbolServer.VarRef # reference to dependency
-                return SymbolServer._lookup(par, getsymbolserver(state), true)
+                return SymbolServer._lookup(par, getsymbols(state), true)
             end
             return par
         end

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -12,7 +12,7 @@ function resolve_import_block(x::EXPR, state::State, root, usinged, markfinal=tr
                 return
             end
         elseif isidentifier(arg) || (i == n && (CSTParser.ismacroname(arg) || isoperator(arg)))
-            root = maybe_lookup(hasref(arg) ? refof(arg) : _get_field(root, arg, state), state.server)
+            root = maybe_lookup(hasref(arg) ? refof(arg) : _get_field(root, arg, state), state)
             setref!(arg, root)
             if i == n
                 markfinal && _mark_import_arg(arg, root, state, usinged)
@@ -112,7 +112,7 @@ function _get_field(par, arg, state)
             return par
         end
         for used_module_name in par.used_modules
-            used_module = maybe_lookup(par[used_module_name], state.server)
+            used_module = maybe_lookup(par[used_module_name], state)
             if used_module !== nothing && isexportedby(Symbol(arg_str_rep), used_module)
                 return used_module[Symbol(arg_str_rep)]
             end
@@ -123,7 +123,7 @@ function _get_field(par, arg, state)
         elseif par.modules !== nothing
             for used_module in values(par.modules)
                 if used_module isa SymbolServer.ModuleStore && isexportedby(Symbol(arg_str_rep), used_module)
-                    return maybe_lookup(used_module[Symbol(arg_str_rep)], state.server)
+                    return maybe_lookup(used_module[Symbol(arg_str_rep)], state)
                 elseif used_module isa Scope && scope_exports(used_module, arg_str_rep, state)
                     return used_module.names[arg_str_rep]
                 end

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -97,7 +97,9 @@ function _get_field(par, arg, state)
         if (arg_scope = retrieve_scope(arg)) !== nothing && (tlm = get_named_toplevel_module(arg_scope, arg_str_rep)) !== nothing && hasbinding(tlm)
             return bindingof(tlm)
         elseif haskey(par, Symbol(arg_str_rep))
-            return par[Symbol(arg_str_rep)]
+            if isempty(state.env.project_deps) || Symbol(arg_str_rep) in state.env.project_deps
+                return par[Symbol(arg_str_rep)]
+            end
         end
     elseif par isa SymbolServer.ModuleStore # imported module
         if Symbol(arg_str_rep) === par.name.name

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -37,9 +37,6 @@ function resolve_import(x::EXPR, state::State, root=getsymbols(state))
                 resolve_import_block(x.args[i], state, root, usinged)
             end
         end
-        for i = 1:length(x.args)
-            resolve_import_block(x.args[i], state, root, usinged)
-        end
     end
 end
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -4,7 +4,7 @@ function resolve_import_block(x::EXPR, state::State, root, usinged, markfinal=tr
         arg = x.args[i]
         if isoperator(arg) && valof(arg) == "."
             # Leading dots. Can only be leading elements.
-            if root == getsymbolserver(state.server)
+            if root == getsymbolserver(state)
                 root = state.scope
             elseif root isa Scope && parentof(root) !== nothing
                 root = parentof(root)
@@ -24,7 +24,7 @@ function resolve_import_block(x::EXPR, state::State, root, usinged, markfinal=tr
     end
 end
 
-function resolve_import(x::EXPR, state::State, root=getsymbolserver(state.server))
+function resolve_import(x::EXPR, state::State, root=getsymbolserver(state))
     if headof(x) === :using || headof(x) === :import
         usinged = headof(x) === :using
         if length(x.args) > 0 && isoperator(headof(x.args[1])) && valof(headof(x.args[1])) == ":"
@@ -49,7 +49,7 @@ function _mark_import_arg(arg, par, state, usinged)
             push!(par.refs, arg)
         end
         if par isa SymbolServer.VarRef
-            par = SymbolServer._lookup(par, getsymbolserver(state.server), true)
+            par = SymbolServer._lookup(par, getsymbolserver(state), true)
             !(par isa SymbolServer.SymStore) && return
         end
         if bindingof(arg) === nothing
@@ -108,7 +108,7 @@ function _get_field(par, arg, state)
         elseif haskey(par, Symbol(arg_str_rep))
             par = par[Symbol(arg_str_rep)]
             if par isa SymbolServer.VarRef # reference to dependency
-                return SymbolServer._lookup(par, getsymbolserver(state.server), true)
+                return SymbolServer._lookup(par, getsymbolserver(state), true)
             end
             return par
         end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -22,7 +22,7 @@ function lint_string(s::String, server = setup_server(); gethints = false)
     semantic_pass(f)
     check_all(f.cst, LintOptions(), env)
     if gethints
-        return f.cst, [(x, string(haserror(x) ? LintCodeDescriptions[x.meta.error] : "Missing reference", " at offset ", offset)) for (offset, x) in collect_hints(f.cst, server)]
+        return f.cst, [(x, string(haserror(x) ? LintCodeDescriptions[x.meta.error] : "Missing reference", " at offset ", offset)) for (offset, x) in collect_hints(f.cst, env)]
     else
         return f.cst
     end
@@ -47,7 +47,7 @@ function lint_file(rootpath, server = setup_server(); gethints = false)
     if gethints
         hints = []
         for (p,f) in server.files
-            append!(hints, [(x, string(haserror(x) ? LintCodeDescriptions[x.meta.error] : "Missing reference", " at offset ", offset, " of ", p)) for (offset, x) in collect_hints(f.cst, server)])
+            append!(hints, [(x, string(haserror(x) ? LintCodeDescriptions[x.meta.error] : "Missing reference", " at offset ", offset, " of ", p)) for (offset, x) in collect_hints(f.cst, getenv(f, server))])
         end
         return root, hints
     else

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -15,11 +15,12 @@ it is paired with a collected list of errors/hints.
 """
 function lint_string(s::String, server = setup_server(); gethints = false)
     empty!(server.files)
-    f = StaticLint.File("", s, CSTParser.parse(s, true), nothing, server)
-    StaticLint.setroot(f, f)
-    StaticLint.setfile(server, "", f)
-    StaticLint.semantic_pass(f)
-    StaticLint.check_all(f.cst, StaticLint.LintOptions(), server)
+    f = File("", s, CSTParser.parse(s, true), nothing, server)
+    env = get_env(f, server)
+    setroot(f, f)
+    setfile(server, "", f)
+    semantic_pass(f)
+    check_all(f.cst, LintOptions(), env)
     if gethints
         return f.cst, [(x, string(haserror(x) ? LintCodeDescriptions[x.meta.error] : "Missing reference", " at offset ", offset)) for (offset, x) in collect_hints(f.cst, server)]
     else
@@ -38,10 +39,10 @@ containing the `File`s of the package.
 """
 function lint_file(rootpath, server = setup_server(); gethints = false)
     empty!(server.files)
-    root = StaticLint.loadfile(server, rootpath)
-    StaticLint.semantic_pass(root)
+    root = loadfile(server, rootpath)
+    semantic_pass(root)
     for (p,f) in server.files
-        StaticLint.check_all(f.cst, StaticLint.LintOptions(), server)
+        check_all(f.cst, LintOptions(), get_env(f, server))
     end
     if gethints
         hints = []

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -16,7 +16,7 @@ it is paired with a collected list of errors/hints.
 function lint_string(s::String, server = setup_server(); gethints = false)
     empty!(server.files)
     f = File("", s, CSTParser.parse(s, true), nothing, server)
-    env = get_env(f, server)
+    env = getenv(f, server)
     setroot(f, f)
     setfile(server, "", f)
     semantic_pass(f)
@@ -42,7 +42,7 @@ function lint_file(rootpath, server = setup_server(); gethints = false)
     root = loadfile(server, rootpath)
     semantic_pass(root)
     for (p,f) in server.files
-        check_all(f.cst, LintOptions(), get_env(f, server))
+        check_all(f.cst, LintOptions(), getenv(f, server))
     end
     if gethints
         hints = []

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -583,7 +583,7 @@ function should_mark_missing_getfield_ref(x, env)
             return true
         elseif lhsref isa Binding
             # by-use type inference runs after we've resolved references so we may not have known lhsref's type first time round, lets try and find `x` again
-            resolve_getfield(x, lhsref, ResolveOnly(retrieve_scope(x), server))
+            resolve_getfield(x, lhsref, ResolveOnly(retrieve_scope(x), env, nothing)) # FIXME: Setting `server` to nothing might be sketchy?
             hasref(x) && return false # We've resolved
             if lhsref.val isa Binding
                 lhsref = lhsref.val

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -125,18 +125,18 @@ end
 
 function _points_to_Base_macro(x::EXPR, name, state)
     CSTParser.is_getfield_w_quotenode(x) && return _points_to_Base_macro(x.args[2].args[1], name, state)
-    haskey(getsymbolserver(state)[:Base], name) || return false
-    targetmacro =  maybe_lookup(getsymbolserver(state)[:Base][name], state.server)
+    haskey(getsymbols(state)[:Base], name) || return false
+    targetmacro =  maybe_lookup(getsymbols(state)[:Base][name], state.server)
     isidentifier(x) && Symbol(valofid(x)) == name && (ref = refof(x)) !== nothing &&
     (ref == targetmacro || (ref isa Binding && ref.val == targetmacro))
 end
 
 function _points_to_arbitrary_macro(x::EXPR, module_name, name, state)
-    length(x.args) == 2 && isidentifier(x.args[2]) && valof(x.args[2]) == name && haskey(getsymbolserver(state), Symbol(module_name)) && haskey(getsymbolserver(state)[Symbol(module_name)], Symbol("@", name)) && (refof(x.args[2]) == maybe_lookup(getsymbolserver(state)[Symbol(module_name)][Symbol("@", name)], state.server) ||
-    (refof(x.args[2]) isa Binding && refof(x.args[2]).val == maybe_lookup(getsymbolserver(state)[Symbol(module_name)][Symbol("@", name)], state.server)))
+    length(x.args) == 2 && isidentifier(x.args[2]) && valof(x.args[2]) == name && haskey(getsymbols(state), Symbol(module_name)) && haskey(getsymbols(state)[Symbol(module_name)], Symbol("@", name)) && (refof(x.args[2]) == maybe_lookup(getsymbols(state)[Symbol(module_name)][Symbol("@", name)], state.server) ||
+    (refof(x.args[2]) isa Binding && refof(x.args[2]).val == maybe_lookup(getsymbols(state)[Symbol(module_name)][Symbol("@", name)], state.server)))
 end
 
-maybe_lookup(x, server) = x isa SymbolServer.VarRef ? SymbolServer._lookup(x, getsymbolserver(server), true) : x
+maybe_lookup(x, server) = x isa SymbolServer.VarRef ? SymbolServer._lookup(x, getsymbols(server), true) : x
 
 function maybe_eventually_get_id(x::EXPR)
     if isidentifier(x)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -125,15 +125,15 @@ end
 
 function _points_to_Base_macro(x::EXPR, name, state)
     CSTParser.is_getfield_w_quotenode(x) && return _points_to_Base_macro(x.args[2].args[1], name, state)
-    haskey(getsymbolserver(state.server)[:Base], name) || return false
-    targetmacro =  maybe_lookup(getsymbolserver(state.server)[:Base][name], state.server)
+    haskey(getsymbolserver(state)[:Base], name) || return false
+    targetmacro =  maybe_lookup(getsymbolserver(state)[:Base][name], state.server)
     isidentifier(x) && Symbol(valofid(x)) == name && (ref = refof(x)) !== nothing &&
     (ref == targetmacro || (ref isa Binding && ref.val == targetmacro))
 end
 
 function _points_to_arbitrary_macro(x::EXPR, module_name, name, state)
-    length(x.args) == 2 && isidentifier(x.args[2]) && valof(x.args[2]) == name && haskey(getsymbolserver(state.server), Symbol(module_name)) && haskey(getsymbolserver(state.server)[Symbol(module_name)], Symbol("@", name)) && (refof(x.args[2]) == maybe_lookup(getsymbolserver(state.server)[Symbol(module_name)][Symbol("@", name)], state.server) ||
-    (refof(x.args[2]) isa Binding && refof(x.args[2]).val == maybe_lookup(getsymbolserver(state.server)[Symbol(module_name)][Symbol("@", name)], state.server)))
+    length(x.args) == 2 && isidentifier(x.args[2]) && valof(x.args[2]) == name && haskey(getsymbolserver(state), Symbol(module_name)) && haskey(getsymbolserver(state)[Symbol(module_name)], Symbol("@", name)) && (refof(x.args[2]) == maybe_lookup(getsymbolserver(state)[Symbol(module_name)][Symbol("@", name)], state.server) ||
+    (refof(x.args[2]) isa Binding && refof(x.args[2]).val == maybe_lookup(getsymbolserver(state)[Symbol(module_name)][Symbol("@", name)], state.server)))
 end
 
 maybe_lookup(x, server) = x isa SymbolServer.VarRef ? SymbolServer._lookup(x, getsymbolserver(server), true) : x

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -144,17 +144,18 @@ end
 function _points_to_Base_macro(x::EXPR, name, state)
     CSTParser.is_getfield_w_quotenode(x) && return _points_to_Base_macro(x.args[2].args[1], name, state)
     haskey(getsymbols(state)[:Base], name) || return false
-    targetmacro =  maybe_lookup(getsymbols(state)[:Base][name], state.server)
+    targetmacro =  maybe_lookup(getsymbols(state)[:Base][name], state)
     isidentifier(x) && Symbol(valofid(x)) == name && (ref = refof(x)) !== nothing &&
     (ref == targetmacro || (ref isa Binding && ref.val == targetmacro))
 end
 
 function _points_to_arbitrary_macro(x::EXPR, module_name, name, state)
-    length(x.args) == 2 && isidentifier(x.args[2]) && valof(x.args[2]) == name && haskey(getsymbols(state), Symbol(module_name)) && haskey(getsymbols(state)[Symbol(module_name)], Symbol("@", name)) && (refof(x.args[2]) == maybe_lookup(getsymbols(state)[Symbol(module_name)][Symbol("@", name)], state.server) ||
-    (refof(x.args[2]) isa Binding && refof(x.args[2]).val == maybe_lookup(getsymbols(state)[Symbol(module_name)][Symbol("@", name)], state.server)))
+    length(x.args) == 2 && isidentifier(x.args[2]) && valof(x.args[2]) == name && haskey(getsymbols(state), Symbol(module_name)) && haskey(getsymbols(state)[Symbol(module_name)], Symbol("@", name)) && (refof(x.args[2]) == maybe_lookup(getsymbols(state)[Symbol(module_name)][Symbol("@", name)], state) ||
+    (refof(x.args[2]) isa Binding && refof(x.args[2]).val == maybe_lookup(getsymbols(state)[Symbol(module_name)][Symbol("@", name)], state)))
 end
 
-maybe_lookup(x, server) = x isa SymbolServer.VarRef ? SymbolServer._lookup(x, getsymbols(server), true) : x
+maybe_lookup(x, env::ExternalEnv) = x isa SymbolServer.VarRef ? SymbolServer._lookup(x, getsymbols(env), true) : x
+maybe_lookup(x, state::State) = maybe_lookup(x, state.env)
 
 function maybe_eventually_get_id(x::EXPR)
     if isidentifier(x)

--- a/src/references.jl
+++ b/src/references.jl
@@ -87,7 +87,7 @@ function resolve_ref_from_module(x1::EXPR, m::SymbolServer.ModuleStore, state::S
 
         mn = Symbol(valof(x))
         if isexportedby(mn, m)
-            setref!(x, maybe_lookup(m[mn], state.server))
+            setref!(x, maybe_lookup(m[mn], state))
             return true
         end
     elseif isidentifier(x1)
@@ -96,7 +96,7 @@ function resolve_ref_from_module(x1::EXPR, m::SymbolServer.ModuleStore, state::S
             setref!(x, m)
             return true
         elseif isexportedby(x, m)
-            setref!(x, maybe_lookup(m[Symbol(valof(x))], state.server))
+            setref!(x, maybe_lookup(m[Symbol(valof(x))], state))
             return true
         end
     end
@@ -233,10 +233,10 @@ end
 function resolve_getfield(x::EXPR, m::SymbolServer.ModuleStore, state::State)::Bool
     hasref(x) && return true
     resolved = false
-    if CSTParser.ismacroname(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbols(state)), state.server)) !== nothing
+    if CSTParser.ismacroname(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbols(state)), state)) !== nothing
         setref!(x, val)
         resolved = true
-    elseif isidentifier(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbols(state)), state.server)) !== nothing
+    elseif isidentifier(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbols(state)), state)) !== nothing
         # Check whether variable is overloaded in top-level scope
         tls = retrieve_toplevel_scope(state.scope)
         # if tls.overloaded !== nothing && (vr = val.name isa SymbolServer.FakeTypeName ? val.name.name : val.name; haskey(tls.overloaded, vr))

--- a/src/references.jl
+++ b/src/references.jl
@@ -124,7 +124,7 @@ Does the scope export a variable called `name`?
 """
 function scope_exports(scope::Scope, name::String, state)
     if scopehasbinding(scope, name) && (b = scope.names[name]) isa Binding
-        initial_pass_on_exports(scope.expr, name, state.server)
+        initial_pass_on_exports(scope.expr, name, state)
         for ref in b.refs
             if ref isa EXPR && parentof(ref) isa EXPR && headof(parentof(ref)) === :export
                 return true
@@ -141,13 +141,13 @@ Export statements need to be (pseudo) evaluated each time we consider
 whether a variable is made available by an import statement.
 """
 
-function initial_pass_on_exports(x::EXPR, name, server)
+function initial_pass_on_exports(x::EXPR, name, state)
     for a in x.args[3] # module block expressions
         if headof(a) === :export
             for i = 1:length(a.args)
                 if isidentifier(a.args[i]) && valof(a.args[i]) == name
                     if !hasref(a.args[i])
-                        Delayed(scopeof(x), server)(a.args[i])
+                        Delayed(scopeof(x), state.env, state.server)(a.args[i])
                     end
                 end
             end

--- a/src/references.jl
+++ b/src/references.jl
@@ -124,7 +124,7 @@ Does the scope export a variable called `name`?
 """
 function scope_exports(scope::Scope, name::String, state)
     if scopehasbinding(scope, name) && (b = scope.names[name]) isa Binding
-        initial_pass_on_exports(scope.expr, state.server)
+        initial_pass_on_exports(scope.expr, state)
         for ref in b.refs
             if ref isa EXPR && parentof(ref) isa EXPR && headof(parentof(ref)) === :export
                 return true
@@ -140,11 +140,11 @@ end
 Export statements need to be (pseudo) evaluated each time we consider 
 whether a variable is made available by an import statement.
 """
-function initial_pass_on_exports(x::EXPR, server)
+function initial_pass_on_exports(x::EXPR, state)
     # @assert CSTParser.defines_module(x)
     for a in x.args[3] # module block expressions
         if headof(a) === :export
-            traverse(a, Delayed(retrieve_scope(a), server))
+            traverse(a, Delayed(retrieve_scope(a), state.env, state.server))
         end
     end
 end
@@ -227,10 +227,10 @@ end
 function resolve_getfield(x::EXPR, m::SymbolServer.ModuleStore, state::State)::Bool
     hasref(x) && return true
     resolved = false
-    if CSTParser.ismacroname(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbolserver(state.server)), state.server)) !== nothing
+    if CSTParser.ismacroname(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbolserver(state)), state.server)) !== nothing
         setref!(x, val)
         resolved = true
-    elseif isidentifier(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbolserver(state.server)), state.server)) !== nothing
+    elseif isidentifier(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbolserver(state)), state.server)) !== nothing
         # Check whether variable is overloaded in top-level scope
         tls = retrieve_toplevel_scope(state.scope)
         # if tls.overloaded !== nothing && (vr = val.name isa SymbolServer.FakeTypeName ? val.name.name : val.name; haskey(tls.overloaded, vr))
@@ -267,7 +267,7 @@ function resolve_getfield(x::EXPR, parent::SymbolServer.DataTypeStore, state::St
     if isidentifier(x) && Symbol(valof(x)) in parent.fieldnames
         fi = findfirst(f -> Symbol(valof(x)) == f, parent.fieldnames)
         ft = parent.types[fi]
-        val = SymbolServer._lookup(ft, getsymbolserver(state.server), true)
+        val = SymbolServer._lookup(ft, getsymbolserver(state), true)
         # TODO: Need to handle the case where we get back a FakeUnion, etc.
         setref!(x, Binding(noname, nothing, val, []))
         resolved = true

--- a/src/references.jl
+++ b/src/references.jl
@@ -227,10 +227,10 @@ end
 function resolve_getfield(x::EXPR, m::SymbolServer.ModuleStore, state::State)::Bool
     hasref(x) && return true
     resolved = false
-    if CSTParser.ismacroname(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbolserver(state)), state.server)) !== nothing
+    if CSTParser.ismacroname(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbols(state)), state.server)) !== nothing
         setref!(x, val)
         resolved = true
-    elseif isidentifier(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbolserver(state)), state.server)) !== nothing
+    elseif isidentifier(x) && (val = maybe_lookup(SymbolServer.maybe_getfield(Symbol(valofid(x)), m, getsymbols(state)), state.server)) !== nothing
         # Check whether variable is overloaded in top-level scope
         tls = retrieve_toplevel_scope(state.scope)
         # if tls.overloaded !== nothing && (vr = val.name isa SymbolServer.FakeTypeName ? val.name.name : val.name; haskey(tls.overloaded, vr))
@@ -267,7 +267,7 @@ function resolve_getfield(x::EXPR, parent::SymbolServer.DataTypeStore, state::St
     if isidentifier(x) && Symbol(valof(x)) in parent.fieldnames
         fi = findfirst(f -> Symbol(valof(x)) == f, parent.fieldnames)
         ft = parent.types[fi]
-        val = SymbolServer._lookup(ft, getsymbolserver(state), true)
+        val = SymbolServer._lookup(ft, getsymbols(state), true)
         # TODO: Need to handle the case where we get back a FakeUnion, etc.
         setref!(x, Binding(noname, nothing, val, []))
         resolved = true

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -124,12 +124,12 @@ function scopes(x::EXPR, state)
         state.scope = scopeof(x)
         if headof(x) === :module && headof(x.args[1]) === :TRUE # Add default modules to a new module
             state.scope.modules = Dict{Symbol,Any}() # TODO: only create new Dict if not assigned?
-            state.scope.modules[:Base] = getsymbolserver(state.server)[:Base]
-            state.scope.modules[:Core] = getsymbolserver(state.server)[:Core]
+            state.scope.modules[:Base] = getsymbolserver(state)[:Base]
+            state.scope.modules[:Core] = getsymbolserver(state)[:Core]
             add_eval_method(x, state)
         elseif headof(x) === :module && headof(x.args[1]) === :FALSE
             state.scope.modules = Dict{String,Any}()
-            state.scope.modules[:Core] = getsymbolserver(state.server)[:Core]
+            state.scope.modules[:Core] = getsymbolserver(state)[:Core]
             add_eval_method(x, state)
         end
         if headof(x) === :module && bindingof(x) !== nothing # Add reference to out of scope binding (i.e. itself)
@@ -151,5 +151,5 @@ function add_eval_method(x, state)
         Symbol("top-level")
     end
     meth = SymbolServer.MethodStore(:eval, mod, "", 0, [:expr => SymbolServer.FakeTypeName(SymbolServer.VarRef(SymbolServer.VarRef(nothing, :Core), :Any), [])], [], Any)
-    state.scope.names["eval"] = Binding(x, SymbolServer.FunctionStore(SymbolServer.VarRef(nothing, :nothing), SymbolServer.MethodStore[meth],"", SymbolServer.VarRef(nothing, :nothing), false), getsymbolserver(state.server)[:Core][:DataType], [])
+    state.scope.names["eval"] = Binding(x, SymbolServer.FunctionStore(SymbolServer.VarRef(nothing, :nothing), SymbolServer.MethodStore[meth],"", SymbolServer.VarRef(nothing, :nothing), false), getsymbolserver(state)[:Core][:DataType], [])
 end

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -124,12 +124,12 @@ function scopes(x::EXPR, state)
         state.scope = scopeof(x)
         if headof(x) === :module && headof(x.args[1]) === :TRUE # Add default modules to a new module
             state.scope.modules = Dict{Symbol,Any}() # TODO: only create new Dict if not assigned?
-            state.scope.modules[:Base] = getsymbolserver(state)[:Base]
-            state.scope.modules[:Core] = getsymbolserver(state)[:Core]
+            state.scope.modules[:Base] = getsymbols(state)[:Base]
+            state.scope.modules[:Core] = getsymbols(state)[:Core]
             add_eval_method(x, state)
         elseif headof(x) === :module && headof(x.args[1]) === :FALSE
             state.scope.modules = Dict{String,Any}()
-            state.scope.modules[:Core] = getsymbolserver(state)[:Core]
+            state.scope.modules[:Core] = getsymbols(state)[:Core]
             add_eval_method(x, state)
         end
         if headof(x) === :module && bindingof(x) !== nothing # Add reference to out of scope binding (i.e. itself)
@@ -151,5 +151,5 @@ function add_eval_method(x, state)
         Symbol("top-level")
     end
     meth = SymbolServer.MethodStore(:eval, mod, "", 0, [:expr => SymbolServer.FakeTypeName(SymbolServer.VarRef(SymbolServer.VarRef(nothing, :Core), :Any), [])], [], Any)
-    state.scope.names["eval"] = Binding(x, SymbolServer.FunctionStore(SymbolServer.VarRef(nothing, :nothing), SymbolServer.MethodStore[meth],"", SymbolServer.VarRef(nothing, :nothing), false), getsymbolserver(state)[:Core][:DataType], [])
+    state.scope.names["eval"] = Binding(x, SymbolServer.FunctionStore(SymbolServer.VarRef(nothing, :nothing), SymbolServer.MethodStore[meth],"", SymbolServer.VarRef(nothing, :nothing), false), getsymbols(state)[:Core][:DataType], [])
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -2,7 +2,7 @@
 Project trees are usually made up of multiple files. An AbstractServer holds the AbstractFiles that represent this tree. FileServer is the basic implementation and assumes files are available and readable from disc. (LanguageServer illustrates another implementaiton). The accompanying functions summarised below are required for making an alternative implementation. 
 
 Interface spec.
-AbstractServer :-> (has/canload/load/set/get)file, getsymbolserver, getsymbolextends
+AbstractServer :-> (has/canload/load/set/get)file, getsymbols, getsymbolextends
 AbstractFile :-> (get/set)path, (get/set)root, (get/set)cst, semantic_pass, (get/set)server
 =#
 abstract type AbstractServer end
@@ -38,11 +38,11 @@ function loadfile(server::FileServer, path::String)
     setfile(server, path, f)
     return getfile(server, path)
 end
-getsymbolserver(server::FileServer) = server.symbolserver
+getsymbols(server::FileServer) = server.symbolserver
 getsymbolextendeds(server::FileServer) = server.symbol_extends
-getsymbolserver(state::State) = getsymbolserver(state.env)
+getsymbols(state::State) = getsymbols(state.env)
 getsymbolextendeds(state::State) = getsymbolextendeds(state.env)
-getsymbolserver(env::ExternalEnv) = env.symbols
+getsymbols(env::ExternalEnv) = env.symbols
 getsymbolextendeds(env::ExternalEnv) = env.extended_methods
 
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -47,11 +47,11 @@ getsymbolextendeds(env::ExternalEnv) = env.extended_methods
 
 
 """
-    get_env(file::File, server::FileServer)
+    getenv(file::File, server::FileServer)
 
 Get the relevant `ExternalEnv` for a given file. 
 """
-function get_env(file::File, server::FileServer)
+function getenv(file::File, server::FileServer)
     # For FileServer this approach is equivalent to the previous behaviour. Other AbstractServers 
     # (e.g. LanguageServerInstance) can use this function to associate different files (or trees of 
     # files) with different environments.

--- a/src/server.jl
+++ b/src/server.jl
@@ -40,6 +40,23 @@ function loadfile(server::FileServer, path::String)
 end
 getsymbolserver(server::FileServer) = server.symbolserver
 getsymbolextendeds(server::FileServer) = server.symbol_extends
+getsymbolserver(state::State) = getsymbolserver(state.env)
+getsymbolextendeds(state::State) = getsymbolextendeds(state.env)
+getsymbolserver(env::ExternalEnv) = env.symbols
+getsymbolextendeds(env::ExternalEnv) = env.extended_methods
+
+
+"""
+    get_env(file::File, server::FileServer)
+
+Get the relevant `ExternalEnv` for a given file. 
+"""
+function get_env(file::File, server::FileServer)
+    # For FileServer this approach is equivalent to the previous behaviour. Other AbstractServers 
+    # (e.g. LanguageServerInstance) can use this function to associate different files (or trees of 
+    # files) with different environments.
+    ExternalEnv(server.symbolserver, server.symbol_extends, Symbol[])
+end
 
 
 getpath(file::File) = file.path

--- a/src/server.jl
+++ b/src/server.jl
@@ -37,12 +37,12 @@ function loadfile(server::FileServer, path::String)
     setfile(server, path, f)
     return getfile(server, path)
 end
-getsymbols(server::FileServer) = server.external_env.symbols
-getsymbolextendeds(server::FileServer) = server.external_env.extended_methods
-getsymbols(state::State) = getsymbols(state.env)
-getsymbolextendeds(state::State) = getsymbolextendeds(state.env)
+
 getsymbols(env::ExternalEnv) = env.symbols
+getsymbols(state::State) = getsymbols(state.env)
+
 getsymbolextendeds(env::ExternalEnv) = env.extended_methods
+getsymbolextendeds(state::State) = getsymbolextendeds(state.env)
 
 
 """

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -116,9 +116,9 @@ function infer_type_by_use(b::Binding, env::ExternalEnv)
         elseif type isa SymbolServer.DataTypeStore
             b.type = type
         elseif type isa SymbolServer.VarRef
-            b.type = SymbolServer._lookup(type, getsymbolserver(env)) # could be nothing
+            b.type = SymbolServer._lookup(type, getsymbols(env)) # could be nothing
         elseif type isa SymbolServer.FakeTypeName && isempty(type.parameters)
-            b.type = SymbolServer._lookup(type.name, getsymbolserver(env)) # could be nothing
+            b.type = SymbolServer._lookup(type.name, getsymbols(env)) # could be nothing
         end
     end
 end

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -45,7 +45,7 @@ function infer_type_assignment_rhs(binding, state, scope)
         if refof_rhs isa Binding
             rhs_bind = refof(rhs)
             if refof_rhs.val isa SymbolServer.GenericStore && refof_rhs.val.typ isa SymbolServer.FakeTypeName
-                binding.type = maybe_lookup(refof_rhs.val.typ.name, state.server)
+                binding.type = maybe_lookup(refof_rhs.val.typ.name, state)
             elseif refof_rhs.val isa SymbolServer.FunctionStore
                 binding.type = CoreTypes.Function
             elseif refof_rhs.val isa SymbolServer.DataTypeStore
@@ -54,7 +54,7 @@ function infer_type_assignment_rhs(binding, state, scope)
                 binding.type = refof_rhs.type
             end
         elseif refof_rhs isa SymbolServer.GenericStore && refof_rhs.typ isa SymbolServer.FakeTypeName
-            binding.type = maybe_lookup(refof_rhs.typ.name, state.server)
+            binding.type = maybe_lookup(refof_rhs.typ.name, state)
         elseif refof_rhs isa SymbolServer.FunctionStore
             binding.type = CoreTypes.Function
         elseif refof_rhs isa SymbolServer.DataTypeStore

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -211,14 +211,14 @@ function iterate_over_ss_methods(b::SymbolServer.FunctionStore, tls::Scope, env:
     end
     if b.extends in keys(getsymbolextendeds(env)) && tls.modules !== nothing
         # above should be modified,
-        rootmod = SymbolServer._lookup(b.extends.parent, getsymbolserver(env)) # points to the module containing the initial function declaration
+        rootmod = SymbolServer._lookup(b.extends.parent, getsymbols(env)) # points to the module containing the initial function declaration
         if rootmod !== nothing && haskey(rootmod, b.extends.name) # check rootmod exists, and that it has the variable
             rootfunc = rootmod[b.extends.name]
             # find extensoions
             if haskey(getsymbolextendeds(env), b.extends) # method extensions listed
                 for vr in getsymbolextendeds(env)[b.extends] # iterate over packages with extensions
                     !(SymbolServer.get_top_module(vr) in keys(tls.modules)) && continue
-                    rootmod = SymbolServer._lookup(vr, getsymbolserver(env))
+                    rootmod = SymbolServer._lookup(vr, getsymbols(env))
                     !(rootmod isa SymbolServer.ModuleStore) && continue
                     if haskey(rootmod.vals, b.extends.name) && (rootmod.vals[b.extends.name] isa SymbolServer.FunctionStore || rootmod.vals[b.extends.name] isa SymbolServer.DataTypeStore)# check package is available and has ref
                         for m in rootmod.vals[b.extends.name].methods #
@@ -245,14 +245,14 @@ function iterate_over_ss_methods(b::SymbolServer.DataTypeStore, tls::Scope, env:
     end
     if (bname in keys(getsymbolextendeds(env))) && tls.modules !== nothing
         # above should be modified,
-        rootmod = SymbolServer._lookup(bname.parent, getsymbolserver(env), true) # points to the module containing the initial function declaration
+        rootmod = SymbolServer._lookup(bname.parent, getsymbols(env), true) # points to the module containing the initial function declaration
         if rootmod !== nothing && haskey(rootmod, bname.name) # check rootmod exists, and that it has the variable
             rootfunc = rootmod[bname.name]
             # find extensoions
             if haskey(getsymbolextendeds(env), bname) # method extensions listed
                 for vr in getsymbolextendeds(env)[bname] # iterate over packages with extensions
                     !(SymbolServer.get_top_module(vr) in keys(tls.modules)) && continue
-                    rootmod = SymbolServer._lookup(vr, getsymbolserver(env))
+                    rootmod = SymbolServer._lookup(vr, getsymbols(env))
                     !(rootmod isa SymbolServer.ModuleStore) && continue
                     if haskey(rootmod.vals, bname.name) && (rootmod.vals[bname.name] isa SymbolServer.FunctionStore || rootmod.vals[bname.name] isa SymbolServer.DataTypeStore)# check package is available and has ref
                         for m in rootmod.vals[bname.name].methods #

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -203,22 +203,22 @@ is_toplevel_scope(x::EXPR) = CSTParser.defines_module(x) || headof(x) === :file
 # for a FunctionStore b, checks whether additional methods are provided by other packages
 # f is a function that returns `true` if we want to break early from the loop
 
-iterate_over_ss_methods(b, tls, server, f) = false
-function iterate_over_ss_methods(b::SymbolServer.FunctionStore, tls::Scope, server, f)
+iterate_over_ss_methods(b, tls, env, f) = false
+function iterate_over_ss_methods(b::SymbolServer.FunctionStore, tls::Scope, env::ExternalEnv, f)
     for m in b.methods
         ret = f(m)
         ret && return true
     end
-    if b.extends in keys(getsymbolextendeds(server)) && tls.modules !== nothing
+    if b.extends in keys(getsymbolextendeds(env)) && tls.modules !== nothing
         # above should be modified,
-        rootmod = SymbolServer._lookup(b.extends.parent, getsymbolserver(server)) # points to the module containing the initial function declaration
+        rootmod = SymbolServer._lookup(b.extends.parent, getsymbolserver(env)) # points to the module containing the initial function declaration
         if rootmod !== nothing && haskey(rootmod, b.extends.name) # check rootmod exists, and that it has the variable
             rootfunc = rootmod[b.extends.name]
             # find extensoions
-            if haskey(getsymbolextendeds(server), b.extends) # method extensions listed
-                for vr in getsymbolextendeds(server)[b.extends] # iterate over packages with extensions
+            if haskey(getsymbolextendeds(env), b.extends) # method extensions listed
+                for vr in getsymbolextendeds(env)[b.extends] # iterate over packages with extensions
                     !(SymbolServer.get_top_module(vr) in keys(tls.modules)) && continue
-                    rootmod = SymbolServer._lookup(vr, getsymbolserver(server))
+                    rootmod = SymbolServer._lookup(vr, getsymbolserver(env))
                     !(rootmod isa SymbolServer.ModuleStore) && continue
                     if haskey(rootmod.vals, b.extends.name) && (rootmod.vals[b.extends.name] isa SymbolServer.FunctionStore || rootmod.vals[b.extends.name] isa SymbolServer.DataTypeStore)# check package is available and has ref
                         for m in rootmod.vals[b.extends.name].methods #
@@ -233,7 +233,7 @@ function iterate_over_ss_methods(b::SymbolServer.FunctionStore, tls::Scope, serv
     return false
 end
 
-function iterate_over_ss_methods(b::SymbolServer.DataTypeStore, tls::Scope, server, f)
+function iterate_over_ss_methods(b::SymbolServer.DataTypeStore, tls::Scope, env::ExternalEnv, f)
     if b.name isa SymbolServer.VarRef
         bname = b.name
     elseif b.name isa SymbolServer.FakeTypeName
@@ -243,16 +243,16 @@ function iterate_over_ss_methods(b::SymbolServer.DataTypeStore, tls::Scope, serv
         ret = f(m)
         ret && return true
     end
-    if (bname in keys(getsymbolextendeds(server))) && tls.modules !== nothing
+    if (bname in keys(getsymbolextendeds(env))) && tls.modules !== nothing
         # above should be modified,
-        rootmod = SymbolServer._lookup(bname.parent, getsymbolserver(server), true) # points to the module containing the initial function declaration
+        rootmod = SymbolServer._lookup(bname.parent, getsymbolserver(env), true) # points to the module containing the initial function declaration
         if rootmod !== nothing && haskey(rootmod, bname.name) # check rootmod exists, and that it has the variable
             rootfunc = rootmod[bname.name]
             # find extensoions
-            if haskey(getsymbolextendeds(server), bname) # method extensions listed
-                for vr in getsymbolextendeds(server)[bname] # iterate over packages with extensions
+            if haskey(getsymbolextendeds(env), bname) # method extensions listed
+                for vr in getsymbolextendeds(env)[bname] # iterate over packages with extensions
                     !(SymbolServer.get_top_module(vr) in keys(tls.modules)) && continue
-                    rootmod = SymbolServer._lookup(vr, getsymbolserver(server))
+                    rootmod = SymbolServer._lookup(vr, getsymbolserver(env))
                     !(rootmod isa SymbolServer.ModuleStore) && continue
                     if haskey(rootmod.vals, bname.name) && (rootmod.vals[bname.name] isa SymbolServer.FunctionStore || rootmod.vals[bname.name] isa SymbolServer.DataTypeStore)# check package is available and has ref
                         for m in rootmod.vals[bname.name].methods #

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -874,8 +874,8 @@ f(arg) = arg
         end
 
         let cst = parse_and_pass("f(x::Module) = x.parent1")
-            @test StaticLint.has_getproperty_method(server.symbolserver[:Core][:Module], server)
-            @test !StaticLint.has_getproperty_method(server.symbolserver[:Core][:DataType], server)
+            @test StaticLint.has_getproperty_method(server.external_env.symbols[:Core][:Module], server)
+            @test !StaticLint.has_getproperty_method(server.external_env.symbols[:Core][:DataType], server)
             @test isempty(StaticLint.collect_hints(cst, server))
         end
         let cst = parse_and_pass("f(x::DataType) = x.sdf")
@@ -1060,7 +1060,7 @@ f(arg) = arg
         sin()
         """)
                 @test haskey(cst.meta.scope.names, "sin") #
-                @test first(cst.meta.scope.names["sin"].refs) == server.symbolserver[:Base][:sin]
+                @test first(cst.meta.scope.names["sin"].refs) == server.external_env.symbols[:Base][:sin]
                 @test isempty(StaticLint.collect_hints(cst[2], server))
             end
     # As above but for user defined function


### PR DESCRIPTION
Currently has no effect but puts in place a mechnism to allow the server to specify what collection of SymbolStore cached packages are made available to a given file. For LanguageServer this means a workspace with multiple folders (packages) open could have the appropriate environments made available to each (and additional packages for test folders, etc). 

~Not for immediate merging.~
Ready, will require tagging