### PR TITLE
be more careful when trying to resolve  export statements early

### DIFF
--- a/src/references.jl
+++ b/src/references.jl
@@ -124,7 +124,7 @@ Does the scope export a variable called `name`?
 """
 function scope_exports(scope::Scope, name::String, state)
     if scopehasbinding(scope, name) && (b = scope.names[name]) isa Binding
-        initial_pass_on_exports(scope.expr, state.server)
+        initial_pass_on_exports(scope.expr, name, state.server)
         for ref in b.refs
             if ref isa EXPR && parentof(ref) isa EXPR && headof(parentof(ref)) === :export
                 return true
@@ -140,11 +140,16 @@ end
 Export statements need to be (pseudo) evaluated each time we consider 
 whether a variable is made available by an import statement.
 """
-function initial_pass_on_exports(x::EXPR, server)
-    # @assert CSTParser.defines_module(x)
+function initial_pass_on_exports(x::EXPR, name, server)
     for a in x.args[3] # module block expressions
         if headof(a) === :export
-            traverse(a, Delayed(retrieve_scope(a), server))
+            for i = 1:length(a.args)
+                if isidentifier(a.args[i]) && valof(a.args[i]) == name
+                    if !hasref(a.args[i])
+                        Delayed(scopeof(x), server)(a.args[i])
+                    end
+                end
+            end
         end
     end
 end


### PR DESCRIPTION
Trying to get rid of the stackoverflow errors we've been seeing. 

Not sure this will work solve the issue so a  bit of explanation incase someone else wants to have a crack at it:

When resolving a symbol (the 'target') we check to see whether `using`ed modules exports a symbol matching the target's name. Running a pass on :export statements is delayed (i.e. until after the `Toplevel` pass) as they can reference yet to be defined symbols.,Tthis means that when checking whether a module exports a name we need to resolve all symbols in the :export statement (`initial_pass_on_exports`) given what we know at that point of the scope. The stackoverflow is caused by some loop where, when trying to resolve the export statement we're pingponging back between two (or more) modules trying to load the same symbol/name. I'm 95% certain that's what's happening but am failing to write an example that can recreate it.


