### PR TITLE
Clean Binding references more thoroughly

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -564,7 +564,6 @@ function should_mark_missing_getfield_ref(x, server)
     if isidentifier(x) && !hasref(x) && # x has no ref
     parentof(x) isa EXPR && headof(parentof(x)) === :quotenode && parentof(parentof(x)) isa EXPR && is_getfield(parentof(parentof(x)))  # x is the rhs of a getproperty
         lhsref = refof_maybe_getfield(parentof(parentof(x)).args[1])
-        resolve_getfield(x, lhsref, ResolveOnly(retrieve_scope(x), server))
         hasref(x) && return false # We've resolved
         if lhsref isa SymbolServer.ModuleStore || (lhsref isa Binding && lhsref.val isa SymbolServer.ModuleStore)
             # a module, we should know this.
@@ -616,7 +615,7 @@ function has_getproperty_method(b::Binding)
         return has_getproperty_method(b.val)
     elseif b isa Binding && b.type === CoreTypes.DataType
         for ref in b.refs
-            if is_type_of_call_to_getproperty(ref)
+            if ref isa EXPR && is_type_of_call_to_getproperty(ref)
                 return true
             end
         end

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -564,6 +564,8 @@ function should_mark_missing_getfield_ref(x, server)
     if isidentifier(x) && !hasref(x) && # x has no ref
     parentof(x) isa EXPR && headof(parentof(x)) === :quotenode && parentof(parentof(x)) isa EXPR && is_getfield(parentof(parentof(x)))  # x is the rhs of a getproperty
         lhsref = refof_maybe_getfield(parentof(parentof(x)).args[1])
+        resolve_getfield(x, lhsref, ResolveOnly(retrieve_scope(x), server))
+        hasref(x) && return false # We've resolved
         if lhsref isa SymbolServer.ModuleStore || (lhsref isa Binding && lhsref.val isa SymbolServer.ModuleStore)
             # a module, we should know this.
             return true

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -219,7 +219,8 @@ function interpret_eval(x::EXPR, state)
             if (ref = refof(variable_name)) isa Binding
                 if isassignment(ref.val) && (rhs = maybeget_quotedsymbol(ref.val.args[2])) !== nothing
                     # `name = :something`
-                    toplevel_binding = Binding(rhs, b.val, b.type, [])
+                    toplevel_binding = Binding(rhs, b.val, nothing, [])
+                    settype!(toplevel_binding, b.type)
                     infer_type(toplevel_binding, tls, state)
                     if scopehasbinding(tls, valofid(toplevel_binding.name))
                         tls.names[valofid(toplevel_binding.name)] = toplevel_binding # TODO: do we need to check whether this adds a method?
@@ -229,7 +230,8 @@ function interpret_eval(x::EXPR, state)
                 elseif is_loop_iterator(ref.val) && (names = maybe_quoted_list(rhs_of_iterator(ref.val))) !== nothing
                     # name is of a collection of quoted symbols
                     for name in names
-                        toplevel_binding = Binding(name, b.val, b.type, [])
+                        toplevel_binding = Binding(name, b.val, nothing, [])
+                        settype!(toplevel_binding, b.type)
                         infer_type(toplevel_binding, tls, state)
                         if scopehasbinding(tls, valofid(toplevel_binding.name))
                             tls.names[valofid(toplevel_binding.name)] = toplevel_binding # TODO: do we need to check whether this adds a method?

--- a/src/references.jl
+++ b/src/references.jl
@@ -3,7 +3,7 @@ function setref!(x::EXPR, binding::Binding)
         x.meta = Meta()
     end
     x.meta.ref = binding
-    binding.refs !== nothing && push!(binding.refs, x)
+    push!(binding.refs, x)
 end
 
 function setref!(x::EXPR, binding)

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -1,16 +1,25 @@
+function settype!(b::Binding, type::Binding)
+    push!(type.refs, b)
+    b.type = type
+end
+
+function settype!(b::Binding, type)
+    b.type = type
+end
+
 function infer_type(binding::Binding, scope, state)
     if binding isa Binding
         binding.type !== nothing && return
         if binding.val isa EXPR && CSTParser.defines_module(binding.val)
-            binding.type = CoreTypes.Module
+            settype!(binding, CoreTypes.Module)
         elseif binding.val isa EXPR && CSTParser.defines_function(binding.val)
-            binding.type = CoreTypes.Function
+            settype!(binding, CoreTypes.Function)
         elseif binding.val isa EXPR && CSTParser.defines_datatype(binding.val)
-            binding.type = CoreTypes.DataType
+            settype!(binding, CoreTypes.DataType)
         elseif binding.val isa EXPR
             if isassignment(binding.val)
                 if CSTParser.is_func_call(binding.val.args[1])
-                    binding.type = CoreTypes.Function
+                    settype!(binding, CoreTypes.Function)
                 else
                     infer_type_assignment_rhs(binding, state, scope)
                 end
@@ -30,35 +39,35 @@ function infer_type_assignment_rhs(binding, state, scope)
             if hasref(callname)
                 rb = get_root_method(refof(callname), state.server)
                 if (rb isa Binding && (rb.type == CoreTypes.DataType || rb.val isa SymbolServer.DataTypeStore)) || rb isa SymbolServer.DataTypeStore
-                    binding.type = rb
+                    settype!(binding, rb)
                 end
             end
         end
     elseif headof(rhs) === :INTEGER
-        binding.type = CoreTypes.Int
+        settype!(binding, CoreTypes.Int)
     elseif headof(rhs) === :FLOAT
-        binding.type = CoreTypes.Float64
+        settype!(binding, CoreTypes.Float64)
     elseif CSTParser.isstringliteral(rhs)
-        binding.type = CoreTypes.String
+        settype!(binding, CoreTypes.String)
     elseif isidentifier(rhs) || is_getfield_w_quotenode(rhs)
         refof_rhs = isidentifier(rhs) ? refof(rhs) : refof_maybe_getfield(rhs)
         if refof_rhs isa Binding
             rhs_bind = refof(rhs)
             if refof_rhs.val isa SymbolServer.GenericStore && refof_rhs.val.typ isa SymbolServer.FakeTypeName
-                binding.type = maybe_lookup(refof_rhs.val.typ.name, state.server)
+                settype!(binding, maybe_lookup(refof_rhs.val.typ.name, state.server))
             elseif refof_rhs.val isa SymbolServer.FunctionStore
-                binding.type = CoreTypes.Function
+                settype!(binding, CoreTypes.Function)
             elseif refof_rhs.val isa SymbolServer.DataTypeStore
-                binding.type = CoreTypes.DataType
+                settype!(binding, CoreTypes.DataType)
             else
-                binding.type = refof_rhs.type
+                settype!(binding, refof_rhs.type)
             end
         elseif refof_rhs isa SymbolServer.GenericStore && refof_rhs.typ isa SymbolServer.FakeTypeName
-            binding.type = maybe_lookup(refof_rhs.typ.name, state.server)
+            settype!(binding, maybe_lookup(refof_rhs.typ.name, state.server))
         elseif refof_rhs isa SymbolServer.FunctionStore
-            binding.type = CoreTypes.Function
+            settype!(binding, CoreTypes.Function)
         elseif refof_rhs isa SymbolServer.DataTypeStore
-            binding.type = CoreTypes.DataType
+            settype!(binding, CoreTypes.DataType)
         end
     end
 end
@@ -79,12 +88,12 @@ function infer_type_decl(binding, state, scope)
     if refof(t) isa Binding
         rb = get_root_method(refof(t), state.server)
         if rb isa Binding && rb.type == CoreTypes.DataType
-            binding.type = rb
+            settype!(binding, rb)
         else
-            binding.type = refof(t)
+            settype!(binding, refof(t))
         end
     elseif refof(t) isa SymbolServer.DataTypeStore
-        binding.type = refof(t)
+        settype!(binding, refof(t))
     end
 end
 
@@ -112,13 +121,13 @@ function infer_type_by_use(b::Binding, server)
         type = first(possibletypes)
     
         if type isa Binding
-            b.type = type
+            settype!(b, type)
         elseif type isa SymbolServer.DataTypeStore
-            b.type = type
+            settype!(b, type)
         elseif type isa SymbolServer.VarRef
-            b.type = SymbolServer._lookup(type, getsymbolserver(server)) # could be nothing
+            settype!(b, SymbolServer._lookup(type, getsymbolserver(server))) # could be nothing
         elseif type isa SymbolServer.FakeTypeName && isempty(type.parameters)
-            b.type = SymbolServer._lookup(type.name, getsymbolserver(server)) # could be nothing
+            settype!(b, SymbolServer._lookup(type.name, getsymbolserver(server))) # could be nothing
         end
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,7 +20,11 @@ function clear_binding(x::EXPR)
             if r isa EXPR
                 setref!(r, nothing)
             elseif r isa Binding
-                clear_binding(r)
+                if r.type == bindingof(x)
+                    r.type = nothing
+                else
+                    clear_binding(r)
+                end
             end
         end
         x.meta.binding = nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1532,3 +1532,14 @@ end
     @test StaticLint.haserror(parse_and_pass("function f(z::T) where T end")[1].args[1].args[1].args[2])
 
 end
+
+@testset "clear .type refs" begin
+    cst = parse_and_pass("""
+    struct T end
+    function f(x::T)
+    end
+    """)
+    @test bindingof(cst[2][2][3]).type == bindingof(cst[1])
+    StaticLint.clear_meta(cst[1])
+    @test bindingof(cst[2][2][3]).type === nothing
+end


### PR DESCRIPTION
References to a Binding as another's `.type` were not being cleaned properly - we had links to CST that had been deleted.