### PR TITLE
add get_named_toplevel_module default method

### DIFF
--- a/src/imports.jl
+++ b/src/imports.jl
@@ -82,6 +82,7 @@ function add_to_imported_modules(scope::Scope, name::Symbol, val)
     end
 end
 no_modules_above(s::Scope) = !CSTParser.defines_module(s.expr) || s.parent === nothing || no_modules_above(s.parent)
+function get_named_toplevel_module(s, name) end
 function get_named_toplevel_module(s::Scope, name::String)
     if CSTParser.defines_module(s.expr) 
         m_name = CSTParser.get_name(s.expr)

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -82,7 +82,9 @@ function add_to_imported_modules(scope::Scope, name::Symbol, val)
     end
 end
 no_modules_above(s::Scope) = !CSTParser.defines_module(s.expr) || s.parent === nothing || no_modules_above(s.parent)
-function get_named_toplevel_module(s, name) end
+function get_named_toplevel_module(s, name) 
+    return nothing
+end
 function get_named_toplevel_module(s::Scope, name::String)
     if CSTParser.defines_module(s.expr) 
         m_name = CSTParser.get_name(s.expr)


### PR DESCRIPTION
Fixes #.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
