### PR TITLE
Type inf improvements

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -36,6 +36,8 @@ ischar(x) = iscoretype(x, :Char)
 issymbol(x) = iscoretype(x, :Symbol)
 isint(x) = iscoretype(x, :Int64)
 isfloat(x) = iscoretype(x, :Float64)
+isvector(x) = iscoretype(x, :Vector)
+isarray(x) = iscoretype(x, :Array)
 isva(x::SymbolServer.FakeUnionAll) = isva(x.body)
 @static if Core.Vararg isa Core.Type
     function isva(x)

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -15,6 +15,7 @@ include("coretypes.jl")
 include("bindings.jl")
 include("scope.jl")
 include("subtypes.jl")
+include("methodmatching.jl")
 
 mutable struct Meta
     binding::Union{Nothing,Binding}

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -19,6 +19,7 @@ const DataType = SymbolServer.stdlibs[:Core][:DataType]
 const Function = SymbolServer.stdlibs[:Core][:Function]
 const Module = SymbolServer.stdlibs[:Core][:Module]
 const String = SymbolServer.stdlibs[:Core][:String]
+const Char = SymbolServer.stdlibs[:Core][:Char]
 const Symbol = SymbolServer.stdlibs[:Core][:Symbol]
 const Int = SymbolServer.stdlibs[:Core][:Int]
 const Float64 = SymbolServer.stdlibs[:Core][:Float64]
@@ -34,6 +35,8 @@ else
     isva(x) = x isa SymbolServer.FakeTypeofVararg
 end
 end
+
+const _DataType = SymbolServer.stdlibs[:Core][:DataType]
 
 include("bindings.jl")
 include("scope.jl")

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -21,6 +21,7 @@ const Module = SymbolServer.stdlibs[:Core][:Module]
 const String = SymbolServer.stdlibs[:Core][:String]
 const Char = SymbolServer.stdlibs[:Core][:Char]
 const Symbol = SymbolServer.stdlibs[:Core][:Symbol]
+const Bool = SymbolServer.stdlibs[:Core][:Bool]
 const Int = SymbolServer.stdlibs[:Core][:Int]
 const Float64 = SymbolServer.stdlibs[:Core][:Float64]
 const Vararg = SymbolServer.FakeTypeName(Core.Vararg)

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -25,6 +25,17 @@ const Int = SymbolServer.stdlibs[:Core][:Int]
 const Float64 = SymbolServer.stdlibs[:Core][:Float64]
 const Vararg = SymbolServer.FakeTypeName(Core.Vararg)
 
+iscoretype(x, name) = false
+iscoretype(x::SymbolServer.VarRef, name) = x isa SymbolServer.DataTypeStore && x.name.name == name && x.name isa SymbolServer.VarRef && x.name.parent.name == :Core
+iscoretype(x::SymbolServer.DataTypeStore, name) = x isa SymbolServer.DataTypeStore && x.name.name.name == name && x.name.name isa SymbolServer.VarRef && x.name.name.parent.name == :Core
+isdatatype(x) = iscoretype(x, :DataType)
+isfunction(x) = iscoretype(x, :Function)
+ismodule(x) = iscoretype(x, :Module)
+isstring(x) = iscoretype(x, :String)
+ischar(x) = iscoretype(x, :Char)
+issymbol(x) = iscoretype(x, :Symbol)
+isint(x) = iscoretype(x, :Int64)
+isfloat(x) = iscoretype(x, :Float64)
 isva(x::SymbolServer.FakeUnionAll) = isva(x.body)
 @static if Core.Vararg isa Core.Type
     function isva(x)

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -11,53 +11,10 @@ using SymbolServer: VarRef
 
 const noname = EXPR(:noname, nothing, nothing, 0, 0, nothing, nothing, nothing)
 
-baremodule CoreTypes # Convenience
-using ..SymbolServer
-using Base: ==, @static
-
-const DataType = SymbolServer.stdlibs[:Core][:DataType]
-const Function = SymbolServer.stdlibs[:Core][:Function]
-const Module = SymbolServer.stdlibs[:Core][:Module]
-const String = SymbolServer.stdlibs[:Core][:String]
-const Char = SymbolServer.stdlibs[:Core][:Char]
-const Symbol = SymbolServer.stdlibs[:Core][:Symbol]
-const Bool = SymbolServer.stdlibs[:Core][:Bool]
-const Int = SymbolServer.stdlibs[:Core][:Int]
-const Float64 = SymbolServer.stdlibs[:Core][:Float64]
-const Vararg = SymbolServer.FakeTypeName(Core.Vararg)
-
-iscoretype(x, name) = false
-iscoretype(x::SymbolServer.VarRef, name) = x isa SymbolServer.DataTypeStore && x.name.name == name && x.name isa SymbolServer.VarRef && x.name.parent.name == :Core
-iscoretype(x::SymbolServer.DataTypeStore, name) = x isa SymbolServer.DataTypeStore && x.name.name.name == name && x.name.name isa SymbolServer.VarRef && x.name.name.parent.name == :Core
-isdatatype(x) = iscoretype(x, :DataType)
-isfunction(x) = iscoretype(x, :Function)
-ismodule(x) = iscoretype(x, :Module)
-isstring(x) = iscoretype(x, :String)
-ischar(x) = iscoretype(x, :Char)
-issymbol(x) = iscoretype(x, :Symbol)
-@static if Core.Int == Core.Int64
-    isint(x) = iscoretype(x, :Int64)
-else
-    isint(x) = iscoretype(x, :Int32)
-end
-isfloat(x) = iscoretype(x, :Float64)
-isvector(x) = iscoretype(x, :Vector)
-isarray(x) = iscoretype(x, :Array)
-isva(x::SymbolServer.FakeUnionAll) = isva(x.body)
-@static if Core.Vararg isa Core.Type
-    function isva(x)
-        return (x isa SymbolServer.FakeTypeName && x.name.name == :Vararg &&
-            x.name.parent isa SymbolServer.VarRef && x.name.parent.name == :Core)
-    end
-else
-    isva(x) = x isa SymbolServer.FakeTypeofVararg
-end
-end
-
-const _DataType = SymbolServer.stdlibs[:Core][:DataType]
-
+include("coretypes.jl")
 include("bindings.jl")
 include("scope.jl")
+include("subtypes.jl")
 
 mutable struct Meta
     binding::Union{Nothing,Binding}

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -94,7 +94,7 @@ function (state::Delayed)(x::EXPR)
 
     traverse(x, state)
     if state.scope != s0
-        for (k, b) in state.scope.names
+        for b in values(state.scope.names)
             infer_type_by_use(b, state.server)
             check_unused_binding(b, state.scope)    
         end
@@ -138,7 +138,7 @@ function semantic_pass(file, modified_expr=nothing)
     for x in state.delayed
         if hasscope(x)
             traverse(x, Delayed(scopeof(x), server)) 
-            for (k, b) in scopeof(x).names
+            for b in values(scopeof(x).names)
                 infer_type_by_use(b, state.server)
                 check_unused_binding(b, scopeof(x))
             end

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -34,7 +34,7 @@ ismodule(x) = iscoretype(x, :Module)
 isstring(x) = iscoretype(x, :String)
 ischar(x) = iscoretype(x, :Char)
 issymbol(x) = iscoretype(x, :Symbol)
-@static if Int === Int64
+@static if Core.Int == Core.Int64
     isint(x) = iscoretype(x, :Int64)
 else
     isint(x) = iscoretype(x, :Int32)

--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -34,7 +34,11 @@ ismodule(x) = iscoretype(x, :Module)
 isstring(x) = iscoretype(x, :String)
 ischar(x) = iscoretype(x, :Char)
 issymbol(x) = iscoretype(x, :Symbol)
-isint(x) = iscoretype(x, :Int64)
+@static if Int === Int64
+    isint(x) = iscoretype(x, :Int64)
+else
+    isint(x) = iscoretype(x, :Int32)
+end
 isfloat(x) = iscoretype(x, :Float64)
 isvector(x) = iscoretype(x, :Vector)
 isarray(x) = iscoretype(x, :Array)

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -318,14 +318,14 @@ function add_binding(x, state, scope=state.scope)
                         # Mark as overloaded so that calls to `M.f()` resolve properly.
                         overload_method(tls, b, VarRef(lhs_ref.name, Symbol(name))) # Add to overloaded list but not scope.
                     end
-                elseif lhs_ref isa Binding && lhs_ref.type == CoreTypes.Module
+                elseif lhs_ref isa Binding && CoreTypes.ismodule(lhs_ref.type)
                     if hasscope(lhs_ref.val) && haskey(scopeof(lhs_ref.val).names, name)
                         # Don't need to do anything, name will resolve
                     end
                 end
             else
                 if scopehasbinding(tls, name)
-                    if tls.names[name] isa Binding && ((tls.names[name].type == CoreTypes.Function || tls.names[name].type == CoreTypes.DataType) || tls.names[name] isa SymbolServer.FunctionStore || tls.names[name] isa SymbolServer.DataTypeStore)
+                    if tls.names[name] isa Binding && ((CoreTypes.isfunction(tls.names[name].type) || CoreTypes.isdatatype(tls.names[name].type)) || tls.names[name] isa SymbolServer.FunctionStore || tls.names[name] isa SymbolServer.DataTypeStore)
                         # do nothing name of `x` will resolve to the root method
                     else
                         seterror!(x, CannotDefineFuncAlreadyHasValue)
@@ -383,7 +383,7 @@ function mark_globals(x::EXPR, state)
 end
 
 function name_extends_imported_method(b::Binding)
-    if b.type == CoreTypes.Function && CSTParser.hasparent(b.name) && CSTParser.is_getfield(parentof(b.name))
+    if CoreTypes.isfunction(b.type) && CSTParser.hasparent(b.name) && CSTParser.is_getfield(parentof(b.name))
         if refof_maybe_getfield(parentof(b.name)[1]) !== nothing
 
         end

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -333,7 +333,7 @@ function add_binding(x, state, scope=state.scope)
                         # so lets use the .val instead.
                         existing_binding = existing_binding.val
                     end
-              if tls.names[name] isa Binding && ((CoreTypes.isfunction(tls.names[name].type) || CoreTypes.isdatatype(tls.names[name].type)) || tls.names[name] isa SymbolServer.FunctionStore || tls.names[name] isa SymbolServer.DataTypeStore)
+                if existing_binding isa Binding && ((CoreTypes.isfunction(existing_binding.type) || CoreTypes.isdatatype(existing_binding.type)) || existing_binding isa SymbolServer.FunctionStore || existing_binding isa SymbolServer.DataTypeStore)
                         # do nothing name of `x` will resolve to the root method
                     else
                         seterror!(x, CannotDefineFuncAlreadyHasValue)

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -346,7 +346,7 @@ function add_binding(x, state, scope=state.scope)
             check_const_decl(name, b, scope)
 
             scope.names[name] = b
-        elseif is_soft_scope(scope) && parentof(scope) isa Scope && scopehasbinding(parentof(scope), valofid(b.name))
+        elseif is_soft_scope(scope) && parentof(scope) isa Scope && scopehasbinding(parentof(scope), valofid(b.name)) && !enforce_hard_scope(x, scope)
             add_binding(x, state, scope.parent)
         else
             scope.names[name] = b
@@ -355,6 +355,10 @@ function add_binding(x, state, scope=state.scope)
     elseif bindingof(x) isa SymbolServer.SymStore
         scope.names[valofid(x)] = bindingof(x)
     end
+end
+
+function enforce_hard_scope(x::EXPR, scope)
+    scope.expr.head === :for && is_in_fexpr(x, x-> x == scope.expr.args[1])
 end
 
 name_is_getfield(x) = parentof(x) isa EXPR && parentof(parentof(x)) isa EXPR && CSTParser.is_getfield_w_quotenode(parentof(parentof(x)))

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -333,7 +333,7 @@ function add_binding(x, state, scope=state.scope)
                         # so lets use the .val instead.
                         existing_binding = existing_binding.val
                     end
-                if existing_binding isa Binding && ((CoreTypes.isfunction(existing_binding.type) || CoreTypes.isdatatype(existing_binding.type)) || existing_binding isa SymbolServer.FunctionStore || existing_binding isa SymbolServer.DataTypeStore)
+                    if (existing_binding isa Binding && ((CoreTypes.isfunction(existing_binding.type) || CoreTypes.isdatatype(existing_binding.type))) || existing_binding isa SymbolServer.FunctionStore || existing_binding isa SymbolServer.DataTypeStore)
                         # do nothing name of `x` will resolve to the root method
                     else
                         seterror!(x, CannotDefineFuncAlreadyHasValue)

--- a/src/coretypes.jl
+++ b/src/coretypes.jl
@@ -1,0 +1,43 @@
+baremodule CoreTypes # Convenience
+using ..SymbolServer
+using Base: ==, @static
+
+const Any = SymbolServer.stdlibs[:Core][:Any]
+const DataType = SymbolServer.stdlibs[:Core][:DataType]
+const Function = SymbolServer.stdlibs[:Core][:Function]
+const Module = SymbolServer.stdlibs[:Core][:Module]
+const String = SymbolServer.stdlibs[:Core][:String]
+const Char = SymbolServer.stdlibs[:Core][:Char]
+const Symbol = SymbolServer.stdlibs[:Core][:Symbol]
+const Bool = SymbolServer.stdlibs[:Core][:Bool]
+const Int = SymbolServer.stdlibs[:Core][:Int]
+const Float64 = SymbolServer.stdlibs[:Core][:Float64]
+const Vararg = SymbolServer.FakeTypeName(Core.Vararg)
+
+iscoretype(x, name) = false
+iscoretype(x::SymbolServer.VarRef, name) = x isa SymbolServer.DataTypeStore && x.name.name == name && x.name isa SymbolServer.VarRef && x.name.parent.name == :Core
+iscoretype(x::SymbolServer.DataTypeStore, name) = x isa SymbolServer.DataTypeStore && x.name.name.name == name && x.name.name isa SymbolServer.VarRef && x.name.name.parent.name == :Core
+isdatatype(x) = iscoretype(x, :DataType)
+isfunction(x) = iscoretype(x, :Function)
+ismodule(x) = iscoretype(x, :Module)
+isstring(x) = iscoretype(x, :String)
+ischar(x) = iscoretype(x, :Char)
+issymbol(x) = iscoretype(x, :Symbol)
+@static if Core.Int == Core.Int64
+    isint(x) = iscoretype(x, :Int64)
+else
+    isint(x) = iscoretype(x, :Int32)
+end
+isfloat(x) = iscoretype(x, :Float64)
+isvector(x) = iscoretype(x, :Vector)
+isarray(x) = iscoretype(x, :Array)
+isva(x::SymbolServer.FakeUnionAll) = isva(x.body)
+@static if Core.Vararg isa Core.Type
+    function isva(x)
+        return (x isa SymbolServer.FakeTypeName && x.name.name == :Vararg &&
+            x.name.parent isa SymbolServer.VarRef && x.name.parent.name == :Core)
+    end
+else
+    isva(x) = x isa SymbolServer.FakeTypeofVararg
+end
+end

--- a/src/coretypes.jl
+++ b/src/coretypes.jl
@@ -11,6 +11,10 @@ const Char = SymbolServer.stdlibs[:Core][:Char]
 const Symbol = SymbolServer.stdlibs[:Core][:Symbol]
 const Bool = SymbolServer.stdlibs[:Core][:Bool]
 const Int = SymbolServer.stdlibs[:Core][:Int]
+const UInt8 = SymbolServer.stdlibs[:Core][:UInt8]
+const UInt16 = SymbolServer.stdlibs[:Core][:UInt16]
+const UInt32 = SymbolServer.stdlibs[:Core][:UInt32]
+const UInt64 = SymbolServer.stdlibs[:Core][:UInt64]
 const Float64 = SymbolServer.stdlibs[:Core][:Float64]
 const Vararg = SymbolServer.FakeTypeName(Core.Vararg)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -40,7 +40,7 @@ function lint_file(rootpath, server = setup_server(); gethints = false)
     empty!(server.files)
     root = StaticLint.loadfile(server, rootpath)
     StaticLint.semantic_pass(root)
-    for (p,f) in server.files
+    for f in values(server.files)
         StaticLint.check_all(f.cst, StaticLint.LintOptions(), server)
     end
     if gethints

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -731,7 +731,7 @@ function check_const_decl(name::String, b::Binding, scope)
     else
         prev = scope.names[name]
         if (CoreTypes.isdatatype(prev.type) && !is_mask_binding_of_datatype(prev)) || is_const(prev)
-            if !in_same_if_branch(b.val, prev.val)
+            if b.val isa EXPR && prev.val isa EXPR && !in_same_if_branch(b.val, prev.val)
                 return
             end
             if b.val isa EXPR

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -57,7 +57,7 @@ const LintCodeDescriptions = Dict{LintCodes,String}(IncorrectCallArgs => "Possib
     UnsupportedConstLocalVariable => "Unsupported `const` declaration on local variable.",
     UnassignedKeywordArgument => "Keyword argument not assigned.",
     CannotDefineFuncAlreadyHasValue => "Cannot define function ; it already has a value.",
-    DuplicateFuncArgName => "Function argnument name not unique.",
+    DuplicateFuncArgName => "Function argument name not unique.",
     IncludePathContainsNULL => "Cannot include file, path cotains NULL characters."
     )
 
@@ -494,6 +494,10 @@ function check_farg_unused_(arg, arg_names)
         return false
     end
     b = bindingof(arg)
+    
+    # We don't care about these
+    valof(b.name) isa String && all_underscore(valof(b.name)) && return
+
     if b === nothing ||
         # no refs:
        isempty(b.refs) ||

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -732,12 +732,12 @@ end
 function is_mask_binding_of_datatype(b::Binding)
     b.val isa EXPR && CSTParser.isassignment(b.val) && (rhsref = refof(b.val.args[2])) !== nothing && (rhsref isa SymbolServer.DataTypeStore || (rhsref.val isa EXPR && rhsref.val isa SymbolServer.DataTypeStore) || (rhsref.val isa EXPR && CSTParser.defines_datatype(rhsref.val)))
 end
+
 # check whether a and b are in all the same :if blocks and in the same branches
-function in_same_if_branch(a, b)
-    a_branches = find_if_parents(a)
-    b_branches = find_if_parents(b)
-    
-    return length(a_branches) == length(b_branches) && all(k in keys(b_branches) for k in keys(a_branches)) && all(a_branches[k] == b_branches[k] for k in keys(a_branches))
+in_same_if_branch(a::EXPR, b::EXPR) = in_same_if_branch(find_if_parents(a), find_if_parents(b))
+in_same_if_branch(a::Dict, b::EXPR) = in_same_if_branch(a, find_if_parents(b))
+function in_same_if_branch(a::Dict, b::Dict)
+    return length(a) == length(b) && all(k in keys(b) for k in keys(a)) && all(a[k] == b[k] for k in keys(a))
 end
 
 # find any parent nodes that are :if blocks and a pseudo-index of which branch

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -496,7 +496,7 @@ function check_farg_unused_(arg, arg_names)
     b = bindingof(arg)
     
     # We don't care about these
-    valof(b.name) isa String && all_underscore(valof(b.name)) && return
+    valof(b.name) isa String && all_underscore(valof(b.name)) && return false
 
     if b === nothing ||
         # no refs:

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -731,6 +731,9 @@ function check_const_decl(name::String, b::Binding, scope)
     else
         prev = scope.names[name]
         if (CoreTypes.isdatatype(prev.type) && !is_mask_binding_of_datatype(prev)) || is_const(prev)
+            if !in_same_if_branch(b.val, prev.val)
+                return
+            end
             if b.val isa EXPR
                 seterror!(b.val, InvalidRedefofConst)
             else

--- a/src/methodmatching.jl
+++ b/src/methodmatching.jl
@@ -1,0 +1,237 @@
+function arg_type(arg, ismethod)
+    if ismethod
+        if hasbinding(arg)
+            if bindingof(arg) isa Binding && bindingof(arg).type !== nothing
+                type = bindingof(arg).type
+                if type isa Binding && type.val isa SymbolServer.DataTypeStore
+                    type = type.val
+                end
+                return type
+            end
+        end
+    else
+        if hasref(arg)
+            if refof(arg) isa Binding && refof(arg).type !== nothing
+                type = refof(arg).type
+                if type isa Binding && type.val isa SymbolServer.DataTypeStore
+                    type = type.val
+                end
+                return type
+            end
+        elseif headof(arg) === :STRING
+            return CoreTypes.String
+        elseif headof(arg) === :CHAR
+            return CoreTypes.Char
+        elseif headof(arg) === :FLOAT
+            return CoreTypes.Float64
+        elseif headof(arg) === :INT
+            return CoreTypes.Int
+        elseif headof(arg) === :HEXINT
+            if length(arg.val) < 5
+                return CoreTypes.UInt8
+            elseif length(arg.val) < 7
+                return CoreTypes.UInt16
+            elseif length(arg.val) < 11
+                return CoreTypes.UInt32
+            else
+                return CoreTypes.UInt64
+            end
+        elseif headof(arg) === :TRUE || headof(arg) === :FALSE
+            return CoreTypes.Bool
+        elseif isquotedsymbol(arg)
+            return SymbolServer.stdlibs[:Core][:Symbol]
+        end
+    end
+    # VarRef(VarRef(nothing, :Core), :Any)
+    CoreTypes.Any
+end
+
+isquotedsymbol(x) = x isa EXPR && x.head === :quotenode && length(x.args) == 1 && x.args[1].head === :IDENTIFIER && hastrivia(x)
+
+function call_arg_types(call::EXPR, ismethod)
+    types, kws = [], []
+    call.args === nothing && return types, kws
+    if length(call.args) > 1 && headof(call.args[2]) === :parameters
+        for i = 1:length(call.args[2].args)
+            push!(kws, call.args[2].args[i].args[1])
+        end
+        for i = 3:length(call.args)
+            push!(types, arg_type(call.args[i], ismethod))
+        end
+    else
+        for i = 2:length(call.args)
+            push!(types, arg_type(call.args[i], ismethod))
+        end
+    end
+    types, kws
+end
+
+function method_arg_types(call::EXPR)
+    types, opts, kws = [], [], []
+    call.args === nothing && return types, opts, kws
+    if length(call.args) > 1 && headof(call.args[2]) === :parameters
+        for i = 1:length(call.args[2].args)
+            push!(kws, call.args[2].args[i].args[1])
+        end
+        for i = 3:length(call.args)
+            if CSTParser.iskwarg(call.args[i])
+                push!(opts, arg_type(call.args[i].args[1], true))
+            else
+                push!(types, arg_type(call.args[i], true))
+            end
+        end
+    else
+        for i = 2:length(call.args)
+            if CSTParser.iskwarg(call.args[i])
+                push!(opts, arg_type(call.args[i].args[1], true))
+            else
+                push!(types, arg_type(call.args[i], true))
+            end
+        end
+    end
+    types, opts, kws
+end
+
+function find_methods(x::EXPR, store)
+    possibles = []
+    if iscall(x)
+        length(x.args) === 0 && return possibles
+        func_ref = refof_call_func(x)
+        func_ref === nothing && return possibles
+        args, kws = call_arg_types(x, false)
+        if func_ref isa Binding && func_ref.val isa SymbolServer.FunctionStore ||
+            func_ref isa Binding && func_ref.val isa SymbolServer.DataTypeStore
+            func_ref = func_ref.val
+        end
+        if func_ref isa SymbolServer.FunctionStore || func_ref isa SymbolServer.DataTypeStore
+            for method in func_ref.methods
+                if match_method(args, kws, method, store)
+                    push!(possibles, method)
+                end
+            end
+        elseif func_ref isa Binding
+            if (CoreTypes.isfunction(func_ref.type) || CoreTypes.isdatatype(func_ref.type)) && func_ref.val isa EXPR
+                for method in func_ref.refs
+                    method = get_method(method)
+                    if method !== nothing
+                        if method isa SymbolServer.FunctionStore
+                            for method1 in method.methods
+                                if match_method(args, kws, method1, store)
+                                    push!(possibles, method1)
+                                end
+                            end
+                        elseif match_method(args, kws, method, store)
+                            push!(possibles, method)
+                        end
+                    end
+                end
+            elseif (method = method_of_callable_datatype(func_ref)) !== nothing
+                if match_method(args, kws, method, store)
+                    push!(possibles, method)
+                end
+            end
+        end
+    end
+    possibles
+end
+
+function match_method(args::Vector{Any}, kws::Vector{Any}, method::SymbolServer.MethodStore, store)
+    !isempty(kws) && isempty(method.kws) && return false
+    nmargs = length(method.sig)
+    varargval = nothing
+    if nmargs > 0 && last(method.sig)[2] isa SymbolServer.FakeTypeofVararg
+        if length(args) == nmargs - 1
+            nmargs -= 1
+            # vararg can be zero length
+            droplast = true
+        elseif length(args) >= nmargs
+            # set aside the type param of the Vararg for later use
+            varargval = last(method.sig)[2].T
+        end
+    end
+    if length(args) == nmargs
+        for i in 1:length(args)
+            if varargval !== nothing && i >= nmargs
+                !_issubtype(args[i], varargval, store) && !_issubtype(varargval, args[i], store) && return false
+            else
+                !_issubtype(args[i], method.sig[i][2], store) && !_issubtype(method.sig[i][2], args[i], store) && return false
+            end
+            
+        end
+        return true
+    end
+    return false
+end
+
+function match_method(args::Vector{Any}, kws::Vector{Any}, method::EXPR, store)
+    margs, mkws = [], []
+    vararg = false
+    if CSTParser.defines_struct(method)
+        for i in 1:length(method.args[3].args)
+            arg = method.args[3].args[i]
+            if defines_function(arg)
+                # Hit an inner constructor so forget about the default one.
+                for arg in method.args[3].args
+                    if defines_function(arg)
+                        !match_method(args, kws, arg, store) && return false
+                    end
+                end
+                return true
+            end
+            push!(margs, arg_type(arg, true))
+        end
+    else
+        sig = CSTParser.rem_decl(CSTParser.get_sig(method))
+        margs, mopts, mkws = method_arg_types(sig)
+        # vararg
+        if length(sig.args) > 0
+            if CSTParser.issplat(last(sig.args))
+                vararg = true
+            end
+        end
+    end
+    !isempty(kws) && isempty(mkws) && return false
+
+    if length(margs) < length(args)
+        for i in 1:min(length(mopts), length(args) - length(margs))
+            push!(margs, mopts[i])
+        end
+        if vararg
+            for i in 1:length(args) - length(margs)
+                push!(margs, CoreTypes.Any)
+            end
+        end
+    end
+
+    if length(args) == length(margs) || (vararg && length(args) == length(margs) - 1)
+        for i in 1:length(args)
+            !_issubtype(args[i], margs[i], store) && !_issubtype(margs[i], args[i], store) && return false
+        end
+        return true
+    end
+    return false
+end
+
+function refof_call_func(x)
+    if isidentifier(first(x.args)) && hasref(first(x.args))
+        return refof(first(x.args))
+    elseif is_getfield_w_quotenode(x.args[1]) && (rhs = rhs_of_getfield(x.args[1])) !== nothing && hasref(rhs)
+        return refof(rhs)
+    else
+        return
+    end
+end
+
+function is_sig_of_method(sig::EXPR, method = maybe_get_parent_fexpr(sig, defines_function))
+    method !== nothing && sig == CSTParser.get_sig(method)
+end
+
+function method_of_callable_datatype(b::Binding)
+    if b.type isa Binding && b.type.type === CoreTypes.DataType
+        for ref in b.type.refs
+            if ref isa EXPR && ref.parent isa EXPR && isdeclaration(ref.parent) && is_in_fexpr(ref.parent, x -> x.parent isa EXPR && x.parent.head === :call && x == x.parent.args[1] && is_in_funcdef(x.parent))
+                return get_parent_fexpr(ref, defines_function)
+            end
+        end
+    end
+end

--- a/src/methodmatching.jl
+++ b/src/methodmatching.jl
@@ -143,7 +143,6 @@ function match_method(args::Vector{Any}, kws::Vector{Any}, method::SymbolServer.
         if length(args) == nmargs - 1
             nmargs -= 1
             # vararg can be zero length
-            droplast = true
         elseif length(args) >= nmargs
             # set aside the type param of the Vararg for later use
             varargval = last(method.sig)[2].T
@@ -197,7 +196,7 @@ function match_method(args::Vector{Any}, kws::Vector{Any}, method::EXPR, store)
             push!(margs, mopts[i])
         end
         if vararg
-            for i in 1:length(args) - length(margs)
+            for _ in 1:length(args) - length(margs)
                 push!(margs, CoreTypes.Any)
             end
         end

--- a/src/references.jl
+++ b/src/references.jl
@@ -40,9 +40,9 @@ end
 function resolve_ref(x::EXPR, scope::Scope, state::State)::Bool
     # if the current scope is a soft scope we should check the parent scope first
     # before trying to resolve the ref locally
-    if is_soft_scope(scope) && parentof(scope) isa Scope
-        resolve_ref(x, parentof(scope), state) && return true
-    end
+    # if is_soft_scope(scope) && parentof(scope) isa Scope
+    #     resolve_ref(x, parentof(scope), state) && return true
+    # end
 
     hasref(x) && return true
     resolved = false

--- a/src/server.jl
+++ b/src/server.jl
@@ -22,7 +22,7 @@ mutable struct FileServer <: AbstractServer
     symbolserver::SymbolServer.EnvStore
     symbol_extends::Dict{SymbolServer.VarRef,Vector{SymbolServer.VarRef}}
 end
-FileServer() = FileServer(Dict{String,File}(), Set{File}(), deepcopy(SymbolServer.stdlibs), SymbolServer.collect_extended_methods(SymbolServer.stdlibs))
+FileServer() = FileServer(Dict{String,File}(), Set{File}(), Dict{Symbol,SymbolServer.ModuleStore}(:Base => SymbolServer.stdlibs[:Base], :Core => SymbolServer.stdlibs[:Core]), SymbolServer.collect_extended_methods(SymbolServer.stdlibs))
 
 hasfile(server::FileServer, path::String) = haskey(server.files, path)
 canloadfile(server, path) = isfile(path)

--- a/src/server.jl
+++ b/src/server.jl
@@ -70,7 +70,7 @@ function Base.display(s::FileServer)
     n = length(s.files)
     println(n, "-file Server")
     cnt = 0
-    for (p, f) in s.files
+    for p in keys(s.files)
         cnt += 1
         println(" ", p)
         cnt > 10 && break

--- a/src/subtypes.jl
+++ b/src/subtypes.jl
@@ -31,7 +31,9 @@ _super(a::SymbolServer.DataTypeStore, store) = SymbolServer._lookup(a.super.name
 _super(a::SymbolServer.FakeTypeVar, store) = a.ub
 _super(a::SymbolServer.FakeUnionAll, store) = a.body
 _super(a::SymbolServer.FakeTypeName, store) = _super(SymbolServer._lookup(a.name, store), store)
-_super(a::SymbolServer.FakeTypeofVararg, store) = CoreTypes.Any
+@static if !(Vararg isa Type)
+    _super(a::SymbolServer.FakeTypeofVararg, store) = CoreTypes.Any
+end
 
 function _super(b::Binding, store)
     StaticLint.CoreTypes.isdatatype(b.type) || error()

--- a/src/subtypes.jl
+++ b/src/subtypes.jl
@@ -57,3 +57,14 @@ function _super(x::EXPR, store)::Union{EXPR,Nothing}
         _super(x.args[1], store)
     end
 end
+
+function subtypes(T::Binding)
+    @assert CSTParser.defines_abstract(T.val)
+    subTs = []
+    for r in T.refs
+        if r isa EXPR && r.parent isa EXPR && CSTParser.issubtypedecl(r.parent) && r.parent.parent isa EXPR && CSTParser.defines_datatype(r.parent.parent)
+            push!(subTs, r.parent.parent)
+        end
+    end
+    subTs
+end

--- a/src/subtypes.jl
+++ b/src/subtypes.jl
@@ -1,0 +1,41 @@
+function _issubtype(a, b, store)
+    _isany(b) && return true
+    _type_compare(a, b) && return true
+    sup_a = _super(a, store)
+    _type_compare(sup_a, b) && return true    
+    !_isany(sup_a) && return _issubtype(sup_a, b, store)
+    return false
+end
+
+_isany(x::SymbolServer.DataTypeStore) = x.name.name == VarRef(VarRef(nothing, :Core), :Any)
+_isany(x) = false
+
+_type_compare(a::SymbolServer.DataTypeStore, b::SymbolServer.DataTypeStore) = a.name == b.name
+_type_compare(a, b) = a == b
+
+function _super(a::SymbolServer.DataTypeStore, store)
+    SymbolServer._lookup(a.super.name, store)
+end
+
+function _super(b::Binding, store)
+    StaticLint.CoreTypes.isdatatype(b.type) || error()
+    b.val isa Binding && return _super(b.val, store)
+    sup = _super(b.val, store)
+    if sup isa EXPR && StaticLint.hasref(sup)
+        StaticLint.refof(sup)
+    else
+        store[:Core][:Any]
+    end
+end
+
+function _super(x::EXPR, store)::Union{EXPR,Nothing}
+    if x.head === :struct
+        _super(x.args[2], store)
+    elseif x.head === :abstract || x.head === :primtive
+        _super(x.args[1], store)
+    elseif CSTParser.issubtypedecl(x)
+        x.args[2]
+    elseif CSTParser.isbracketed(x)
+        _super(x.args[1], store)
+    end
+end

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -55,6 +55,16 @@ function infer_type_assignment_rhs(binding, state, scope)
             end
         elseif headof(rhs) === :INTEGER
             settype!(binding, CoreTypes.Int)
+        elseif headof(rhs) === :HEXINT
+            if length(rhs.val) < 5
+                settype!(binding, CoreTypes.UInt8)
+            elseif length(rhs.val) < 7
+                settype!(binding, CoreTypes.UInt16)
+            elseif length(rhs.val) < 11
+                settype!(binding, CoreTypes.UInt32)
+            else
+                settype!(binding, CoreTypes.UInt64)
+            end
         elseif headof(rhs) === :FLOAT
             settype!(binding, CoreTypes.Float64)
         elseif CSTParser.isstringliteral(rhs)

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -57,6 +57,8 @@ function infer_type_assignment_rhs(binding, state, scope)
             settype!(binding, CoreTypes.Float64)
         elseif CSTParser.isstringliteral(rhs)
             settype!(binding, CoreTypes.String)
+        elseif headof(rhs) === :TRUE || headof(rhs) === :false
+            settype!(binding, CoreTypes.Bool)
         elseif isidentifier(rhs) || is_getfield_w_quotenode(rhs)
             refof_rhs = isidentifier(rhs) ? refof(rhs) : refof_maybe_getfield(rhs)
             if refof_rhs isa Binding

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -74,7 +74,6 @@ function infer_type_assignment_rhs(binding, state, scope)
         elseif isidentifier(rhs) || is_getfield_w_quotenode(rhs)
             refof_rhs = isidentifier(rhs) ? refof(rhs) : refof_maybe_getfield(rhs)
             if refof_rhs isa Binding
-                rhs_bind = refof(rhs)
                 if refof_rhs.val isa SymbolServer.GenericStore && refof_rhs.val.typ isa SymbolServer.FakeTypeName
                     settype!(binding, maybe_lookup(refof_rhs.val.typ.name, state.server))
                 elseif refof_rhs.val isa SymbolServer.FunctionStore

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -41,7 +41,7 @@ function infer_type_assignment_rhs(binding, state, scope)
                 resolve_ref(callname, scope, state)
                 if hasref(callname)
                     rb = get_root_method(refof(callname), state.server)
-                    if (rb isa Binding && (rb.type == CoreTypes.DataType || rb.val isa SymbolServer.DataTypeStore)) || rb isa SymbolServer.DataTypeStore
+                    if (rb isa Binding && (CoreTypes.isdatatype(rb.type) || rb.val isa SymbolServer.DataTypeStore)) || rb isa SymbolServer.DataTypeStore
                         settype!(binding, rb)
                     end
                 end
@@ -91,7 +91,7 @@ function infer_type_decl(binding, state, scope)
     end
     if refof(t) isa Binding
         rb = get_root_method(refof(t), state.server)
-        if rb isa Binding && rb.type == CoreTypes.DataType
+        if rb isa Binding && CoreTypes.isdatatype(rb.type)
             settype!(binding, rb)
         else
             settype!(binding, refof(t))
@@ -229,7 +229,7 @@ function infer_eltype(x::EXPR)
     elseif headof(x) === :ref && hasref(x.args[1])
         r = refof(x.args[1]) 
         if r isa SymbolServer.DataTypeStore ||
-            r isa Binding && r.type == CoreTypes.DataType
+            r isa Binding && CoreTypes.isdatatype(r.type)
             r
         end
     elseif headof(x) === :STRING

--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -57,7 +57,7 @@ function infer_type_assignment_rhs(binding, state, scope)
             settype!(binding, CoreTypes.Float64)
         elseif CSTParser.isstringliteral(rhs)
             settype!(binding, CoreTypes.String)
-        elseif headof(rhs) === :TRUE || headof(rhs) === :false
+        elseif headof(rhs) === :TRUE || headof(rhs) === :FALSE
             settype!(binding, CoreTypes.Bool)
         elseif isidentifier(rhs) || is_getfield_w_quotenode(rhs)
             refof_rhs = isidentifier(rhs) ? refof(rhs) : refof_maybe_getfield(rhs)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -90,7 +90,7 @@ function get_root_method(b, server)
 end
 
 function get_root_method(b::Binding, server)
-    if b.type == CoreTypes.Function && !isempty(b.refs)
+    if CoreTypes.isfunction(b.type) && !isempty(b.refs)
         first(b.refs)
     else
         b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1558,3 +1558,5 @@ end
     """)
     @test isempty(StaticLint.collect_hints(cst, server))
 end
+
+include("typeinf.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,24 +164,24 @@ f(arg) = arg
         @test check_resolved("[k * j for j in 1:10 for k in 1:10]") == [1, 1, 1, 1]
 
         @testset "inference" begin
-            @test bindingof(parse_and_pass("f(arg) = arg").args[1]).type == StaticLint.CoreTypes.Function
-            @test bindingof(parse_and_pass("function f end").args[1]).type == StaticLint.CoreTypes.Function
-            @test bindingof(parse_and_pass("struct T end").args[1]).type == StaticLint.CoreTypes.DataType
-            @test bindingof(parse_and_pass("mutable struct T end").args[1]).type == StaticLint.CoreTypes.DataType
-            @test bindingof(parse_and_pass("abstract type T end").args[1]).type == StaticLint.CoreTypes.DataType
-            @test bindingof(parse_and_pass("primitive type T 8 end").args[1]).type == StaticLint.CoreTypes.DataType
-            @test bindingof(parse_and_pass("x = 1").args[1].args[1]).type == StaticLint.CoreTypes.Int
-            @test bindingof(parse_and_pass("x = 1.0").args[1].args[1]).type == StaticLint.CoreTypes.Float64
-            @test bindingof(parse_and_pass("x = \"text\"").args[1].args[1]).type == StaticLint.CoreTypes.String
-            @test bindingof(parse_and_pass("module A end").args[1]).type == StaticLint.CoreTypes.Module
-            @test bindingof(parse_and_pass("baremodule A end").args[1]).type == StaticLint.CoreTypes.Module
+            @test StaticLint.CoreTypes.isfunction(bindingof(parse_and_pass("f(arg) = arg").args[1]).type)
+            @test StaticLint.CoreTypes.isfunction(bindingof(parse_and_pass("function f end").args[1]).type)
+            @test StaticLint.CoreTypes.isdatatype(bindingof(parse_and_pass("struct T end").args[1]).type)
+            @test StaticLint.CoreTypes.isdatatype(bindingof(parse_and_pass("mutable struct T end").args[1]).type)
+            @test StaticLint.CoreTypes.isdatatype(bindingof(parse_and_pass("abstract type T end").args[1]).type)
+            @test StaticLint.CoreTypes.isdatatype(bindingof(parse_and_pass("primitive type T 8 end").args[1]).type)
+            @test StaticLint.CoreTypes.isint(bindingof(parse_and_pass("x = 1").args[1].args[1]).type)
+            @test StaticLint.CoreTypes.isfloat(bindingof(parse_and_pass("x = 1.0").args[1].args[1]).type)
+            @test StaticLint.CoreTypes.isstring(bindingof(parse_and_pass("x = \"text\"").args[1].args[1]).type)
+            @test StaticLint.CoreTypes.ismodule(bindingof(parse_and_pass("module A end").args[1]).type)
+            @test StaticLint.CoreTypes.ismodule(bindingof(parse_and_pass("baremodule A end").args[1]).type)
 
     # @test parse_and_pass("function f(x::Int) x end")[1][2][3].binding.t == StaticLint.getsymbolserver(server)["Core"].vals["Function"]
             let cst = parse_and_pass("""
         struct T end
         function f(x::T) x end""")
-                @test bindingof(cst.args[1]).type == StaticLint.CoreTypes.DataType
-                @test bindingof(cst.args[2]).type == StaticLint.CoreTypes.Function
+                @test StaticLint.CoreTypes.isdatatype(bindingof(cst.args[1]).type)
+                @test StaticLint.CoreTypes.isfunction(bindingof(cst.args[2]).type)
                 @test bindingof(cst.args[2].args[1].args[2]).type == bindingof(cst.args[1])
                 @test refof(cst.args[2].args[2].args[1]) == bindingof(cst.args[2].args[1].args[2])
             end
@@ -189,8 +189,8 @@ f(arg) = arg
         struct T end
         T() = 1
         function f(x::T) x end""")
-                @test bindingof(cst.args[1]).type == StaticLint.CoreTypes.DataType
-                @test bindingof(cst.args[3]).type == StaticLint.CoreTypes.Function
+                @test StaticLint.CoreTypes.isdatatype(bindingof(cst.args[1]).type)
+                @test StaticLint.CoreTypes.isfunction(bindingof(cst.args[3]).type)
                 @test bindingof(cst.args[3].args[1].args[2]).type == bindingof(cst.args[1])
                 @test refof(cst.args[3].args[2].args[1]) == bindingof(cst.args[3].args[1].args[2])
             end
@@ -198,7 +198,7 @@ f(arg) = arg
             let cst = parse_and_pass("""
         struct T end
         t = T()""")
-                @test bindingof(cst.args[1]).type == StaticLint.CoreTypes.DataType
+                @test StaticLint.CoreTypes.isdatatype(bindingof(cst.args[1]).type)
                 @test bindingof(cst.args[2].args[1]).type == bindingof(cst.args[1])
             end
 

--- a/test/typeinf.jl
+++ b/test/typeinf.jl
@@ -89,3 +89,21 @@ for y in Y end
 @test StaticLint.CoreTypes.isint(cst.args[7].meta.scope.names["x"].type)
 @test cst.args[8].meta.scope.names["y"].type == cst.meta.scope.names["T"]
 end
+
+@testset "Vector{T} infer" begin
+cst = parse_and_pass("""
+struct T 
+    t1
+end
+struct S
+    s1::Vector{T}
+end
+
+function f(s::S)
+    t = s.s1[1]
+    t # This should be inferred as T
+end
+""")
+
+@test cst[3].meta.scope.names["t"].type == cst.meta.scope.names["T"]
+end

--- a/test/typeinf.jl
+++ b/test/typeinf.jl
@@ -66,7 +66,9 @@ end
 @testset "loop iterator inference" begin
 cst = parse_and_pass("""
 begin
+abstract type T end
 X = Int[]
+Y = T[]
 end
 
 for x in 1 end
@@ -74,11 +76,16 @@ for x in "abc" end
 for x in 1:10 end
 for x in 1.0:10.0 end
 for x in Int[1,2,3] end
+for x in X end
+for y in Y end
 """);
+
 @test cst.args[2].meta.scope.names["x"].type === nothing
 @test StaticLint.CoreTypes.ischar(cst.args[3].meta.scope.names["x"].type)
 @test StaticLint.CoreTypes.isint(cst.args[4].meta.scope.names["x"].type)
 @test StaticLint.CoreTypes.isfloat(cst.args[5].meta.scope.names["x"].type)
 @test StaticLint.CoreTypes.isint(cst.args[6].meta.scope.names["x"].type)
-
+@test StaticLint.CoreTypes.isint(cst.args[7].meta.scope.names["x"].type)
+@test StaticLint.CoreTypes.isint(cst.args[7].meta.scope.names["x"].type)
+@test cst.args[8].meta.scope.names["y"].type == cst.meta.scope.names["T"]
 end

--- a/test/typeinf.jl
+++ b/test/typeinf.jl
@@ -62,3 +62,23 @@ S = cst.meta.scope.names["S"]
 @test cst.meta.scope.names["ex6"].val.meta.scope.names["y"].type === T
 end
 
+
+@testset "loop iterator inference" begin
+cst = parse_and_pass("""
+begin
+X = Int[]
+end
+
+for x in 1 end
+for x in "abc" end
+for x in 1:10 end
+for x in 1.0:10.0 end
+for x in Int[1,2,3] end
+""");
+@test cst.args[2].meta.scope.names["x"].type === nothing
+@test cst.args[3].meta.scope.names["x"].type === StaticLint.CoreTypes.Char
+@test cst.args[4].meta.scope.names["x"].type === StaticLint.CoreTypes.Int
+@test cst.args[5].meta.scope.names["x"].type === StaticLint.CoreTypes.Float64
+@test cst.args[6].meta.scope.names["x"].type === StaticLint.CoreTypes.Int
+
+end

--- a/test/typeinf.jl
+++ b/test/typeinf.jl
@@ -76,9 +76,9 @@ for x in 1.0:10.0 end
 for x in Int[1,2,3] end
 """);
 @test cst.args[2].meta.scope.names["x"].type === nothing
-@test cst.args[3].meta.scope.names["x"].type === StaticLint.CoreTypes.Char
-@test cst.args[4].meta.scope.names["x"].type === StaticLint.CoreTypes.Int
-@test cst.args[5].meta.scope.names["x"].type === StaticLint.CoreTypes.Float64
-@test cst.args[6].meta.scope.names["x"].type === StaticLint.CoreTypes.Int
+@test StaticLint.CoreTypes.ischar(cst.args[3].meta.scope.names["x"].type)
+@test StaticLint.CoreTypes.isint(cst.args[4].meta.scope.names["x"].type)
+@test StaticLint.CoreTypes.isfloat(cst.args[5].meta.scope.names["x"].type)
+@test StaticLint.CoreTypes.isint(cst.args[6].meta.scope.names["x"].type)
 
 end

--- a/test/typeinf.jl
+++ b/test/typeinf.jl
@@ -1,0 +1,64 @@
+@testset "type inference by use" begin  
+cst = parse_and_pass("""
+struct T 
+end
+
+struct S 
+end
+
+f(x::T) = 1
+g(x::S) = 1
+
+function ex1(x)
+    f(x)
+end
+
+function ex2(x)
+    f(x)
+    g(x)
+end
+
+function ex3(x)
+    if 1
+        f(x)
+    else
+        f(x)
+    end
+end
+
+function ex4(x)
+    x
+    if 1
+        f(x)
+    end
+end
+
+function ex5(x)
+    if 1
+        f(x)
+    else
+        g(x)
+    end
+end
+
+function ex6(x)
+    if 1
+        y = x
+        f(y)
+    else
+        g(x)
+    end
+end
+""");
+
+T = cst.meta.scope.names["T"]
+S = cst.meta.scope.names["S"]
+
+@test cst.meta.scope.names["ex1"].val.meta.scope.names["x"].type == T
+@test cst.meta.scope.names["ex2"].val.meta.scope.names["x"].type === nothing
+@test cst.meta.scope.names["ex3"].val.meta.scope.names["x"].type === nothing
+@test cst.meta.scope.names["ex4"].val.meta.scope.names["x"].type === nothing
+@test cst.meta.scope.names["ex5"].val.meta.scope.names["x"].type === nothing
+@test cst.meta.scope.names["ex6"].val.meta.scope.names["y"].type === T
+end
+


### PR DESCRIPTION
Adds some rudimentary inference for elements of arrays. 

For type inference by use (i.e. where we infer the type of a variable by the argument slot it sits in in a function call) adds handling for `if` blocks so that the uncertainty of whether a branch is hit is accounted for.

Also adds some internal (as yet unused) functions for reasoning about the specific method being used at a call site. The intention is to use this in combination with function return type cached by SymbolServer to improve our inference. [Note - there are currently two different pieces of code that iterate across function methods (`check_call` and `infer_type_by_use`) and use of the functions referenced above would add a third. These should be combined/rationalised.]


For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
