### PR TITLE
infer where type param types

### DIFF
--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -25,6 +25,8 @@ function infer_type(binding::Binding, scope, state)
                 end
             elseif binding.val.head isa EXPR && valof(binding.val.head) == "::"
                 infer_type_decl(binding, state, scope)
+            elseif iswhere(parentof(binding.val))
+                settype!(binding, CoreTypes.DataType)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1570,3 +1570,15 @@ end
     @test cst[2].meta.scope.names["T"].type isa SymbolServer.DataTypeStore
     @test isempty(StaticLint.collect_hints(cst, server))
 end
+
+@testset "where type param infer" begin
+    cst = parse_and_pass("""
+    bar(u::Union) = 1
+    foo(x::T, y::S, q::V) where {T, S <: V} where {V <: Integer} = x + y + q + bar(S) + bar(T) + bar(V)
+    """)
+
+    @test cst[2].meta.scope.names["T"].type isa SymbolServer.DataTypeStore
+    @test cst[2].meta.scope.names["S"].type isa SymbolServer.DataTypeStore
+    @test cst[2].meta.scope.names["V"].type isa SymbolServer.DataTypeStore
+    @test isempty(StaticLint.collect_hints(cst, server))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1558,3 +1558,15 @@ end
     """)
     @test isempty(StaticLint.collect_hints(cst, server))
 end
+
+@testset "where type param infer" begin
+    cst = parse_and_pass("""
+    foo(u::Union) = 1
+    function foo(x::T) where {T}
+        x + foo(T)
+    end
+    """)
+
+    @test cst[2].meta.scope.names["T"].type isa SymbolServer.DataTypeStore
+    @test isempty(StaticLint.collect_hints(cst, server))
+end


### PR DESCRIPTION
Fixes a bug reported on Slack.

Originally we wouldn't mark the `T` in e.g. `foo(x::T) where T = bar(T)` as having a known type, but the use in the `where` expression guarantees it'll be a `DataType` (or `UnionAll`). This was problematic in case the method body can back-propagate `T`'s type, as would be the case in
```
bar(u::Union) = 1
foo(x::T) where {T} = bar(T)
```

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
