### PR TITLE
additional checks for delayed scope retrieval

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -162,7 +162,12 @@ function semantic_pass(file, modified_expr=nothing)
                 infer_type_by_use(b, state.server)
             end
         else
-            traverse(x, Delayed(retrieve_delayed_scope(x), server))
+            scope = retrieve_delayed_scope(x)
+            if scope isa Scope
+                traverse(x, Delayed(scope, server))
+            else
+                @warn "no delayed scope found for $(headof(x))"
+            end
         end
     end
     if state.resolveonly !== nothing
@@ -170,7 +175,12 @@ function semantic_pass(file, modified_expr=nothing)
             if hasscope(x)
                 traverse(x, ResolveOnly(scopeof(x), server))
             else
-                traverse(x, ResolveOnly(retrieve_delayed_scope(x), server))
+                scope = retrieve_delayed_scope(x)
+                if scope isa Scope
+                    traverse(x, Delayed(scope, server))
+                else
+                    @warn "no delayed scope found for $(headof(x))"
+                end
             end
         end
     end


### PR DESCRIPTION
This prevents a LS crash with certain JMD files (see https://github.com/julia-vscode/StaticLint.jl/issues/280), but doesn't fix the cause of the issue.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
