### PR TITLE
disable non-at-eval macrocall linting

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -906,7 +906,7 @@ function is_sig_arg(x)
 end
 
 function is_in_noneval_macrocall(x)
-    macrocall = maybe_get_parent_fexpr(x, x -> x.head === :macrocall && valof(x.args[1]) !== "@eval")
+    macrocall = maybe_get_parent_fexpr(x, x -> x.head === :macrocall && valof(x.args[1]) != "@eval")
     return macrocall !== nothing
 end
 

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -546,7 +546,8 @@ function collect_hints(x::EXPR, env, missingrefs=:all, isquoted=false, errs=Tupl
     elseif !isquoted
         if missingrefs != :none && isidentifier(x) && !hasref(x) &&
             !(valof(x) == "var" && parentof(x) isa EXPR && isnonstdid(parentof(x))) &&
-            !((valof(x) == "stdcall" || valof(x) == "cdecl" || valof(x) == "fastcall" || valof(x) == "thiscall" || valof(x) == "llvmcall") && is_in_fexpr(x, x -> iscall(x) && isidentifier(x.args[1]) && valof(x.args[1]) == "ccall"))
+            !((valof(x) == "stdcall" || valof(x) == "cdecl" || valof(x) == "fastcall" || valof(x) == "thiscall" || valof(x) == "llvmcall") && is_in_fexpr(x, x -> iscall(x) && isidentifier(x.args[1]) && valof(x.args[1]) == "ccall")) &&
+            !is_in_noneval_macrocall(x)
 
             push!(errs, (pos, x))
         elseif haserror(x) && errorof(x) isa StaticLint.LintCodes
@@ -895,6 +896,12 @@ all_underscore(s::String) = all(==(0x5f), codeunits(s))
 function is_sig_arg(x)
     is_in_fexpr(x, CSTParser.iscall)
 end
+
+function is_in_noneval_macrocall(x)
+    macrocall = maybe_get_parent_fexpr(x, x -> x.head === :macrocall && valof(x.args[1]) !== "@eval")
+    return macrocall !== nothing
+end
+
 
 function is_overwritten_in_loop(x)
     # Cuts out false positives for check_unused_binding - the linear nature of our

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1718,3 +1718,14 @@ end
     @test isempty(StaticLint.collect_hints(cst, server))
 
 end
+
+
+@testset "macrocall bindings: #2187" begin
+    cst = parse_and_pass("""
+    function f()
+        @info "Downloading" source = url dest = file
+        return nothing
+    end
+    """)
+    @test isempty(StaticLint.collect_hints(cst, server))
+end


### PR DESCRIPTION
for bindings and refs. This shouldn't be too expensive, even though a bit hacky.

Fixes https://github.com/julia-vscode/julia-vscode/issues/2187.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
