### PR TITLE
Rev290

### DIFF
--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -59,8 +59,6 @@ function mark_bindings!(x::EXPR, state)
             mark_sig_args!(x.args[1])
         elseif CSTParser.iscurly(x.args[1])
             mark_typealias_bindings!(x)
-        elseif is_in_noneval_macrocall(x.args[1])
-            return
         elseif !is_getfield(x.args[1])
             mark_binding!(x.args[1], x)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1748,7 +1748,7 @@ end
 
 @testset "macrocall bindings: #2187" begin
     cst = parse_and_pass("""
-    function f()
+    function f(url = 1, file = 1)
         @info "Downloading" source = url dest = file
         return nothing
     end


### PR DESCRIPTION
Reverses https://github.com/julia-vscode/StaticLint.jl/pull/290 and fixes https://github.com/julia-vscode/julia-vscode/issues/2187.

#290 disabled quite alot of functionality, and went beyond the scope of the initial issue.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
