### PR TITLE
Skip bindings for assignments in @.  

### DIFF
--- a/src/StaticLint.jl
+++ b/src/StaticLint.jl
@@ -61,7 +61,7 @@ mutable struct Toplevel{T} <: State
     resolveonly::Vector{EXPR}
     env::ExternalEnv
     server
-    flags::Int64
+    flags::Int
 end
 
 Toplevel(file, included_files, scope, in_modified_expr, modified_exprs, delayed, resolveonly, env, server) =
@@ -102,7 +102,7 @@ mutable struct Delayed <: State
     scope::Scope
     env::ExternalEnv
     server
-    flags::Int64
+    flags::Int
 end
 
 Delayed(scope, env, server) = Delayed(scope, env, server, 0)

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -59,6 +59,10 @@ function mark_bindings!(x::EXPR, state)
             mark_sig_args!(x.args[1])
         elseif CSTParser.iscurly(x.args[1])
             mark_typealias_bindings!(x)
+        elseif CSTParser.ismacrocall(x.parent) && x.parent.args[1].val == "@."
+            # Skip marking bindings on assignements inside @.
+            # TODO: Check all parent expressions of the assignment for @. and @__dot__
+            return
         elseif !is_getfield(x.args[1])
             mark_binding!(x.args[1], x)
         end

--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -507,8 +507,8 @@ function check_farg_unused_(arg, arg_names)
        isempty(b.refs) ||
         # only self ref:
        (length(b.refs) == 1 && first(b.refs) == b.name) ||
-        # first usage is assignment:
-       (length(b.refs) > 1 && b.refs[2] isa EXPR && CSTParser.hasparent(b.refs[2]) && isassignment(parentof(b.refs[2])) && parentof(b.refs[2]).args[1] == b.refs[2])
+        # first usage has binding:
+        (length(b.refs) > 1 && b.refs[2] isa EXPR && hasbinding(b.refs[2]))
         seterror!(arg, UnusedFunctionArgument)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -789,6 +789,18 @@ f(arg) = arg
             StaticLint.check_farg_unused(cst[1])
             @test cst[1].args[1].args[2].meta.error === nothing
         end
+        let cst = parse_and_pass("""
+            function f(x,y,z)
+                @. begin
+                    x = z
+                    y = z
+                end
+            end
+            """)
+           StaticLint.check_farg_unused(cst[1])
+           @test StaticLint.errorof(CSTParser.get_sig(cst[1])[3]) === nothing
+           @test StaticLint.errorof(CSTParser.get_sig(cst[1])[5]) === nothing
+       end
     end
 
     @testset "check redefinition of const" begin


### PR DESCRIPTION
For any assignment this checks that none of its ancestors is an `@.` call before marking a binding. I'm happy to hear any suggestions if there is a better approach.

Fixes https://github.com/julia-vscode/julia-vscode/issues/2514

