### PR TITLE
Type declarations on global variables are supported on 1.8

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -876,7 +876,7 @@ end
 
 function check_const(x::EXPR)
     if headof(x) === :const
-        if CSTParser.isassignment(x.args[1]) && CSTParser.isdeclaration(x.args[1].args[1])
+        if VERSION < v"1.8.0-DEV.1500" && CSTParser.isassignment(x.args[1]) && CSTParser.isdeclaration(x.args[1].args[1])
             seterror!(x, TypeDeclOnGlobalVariable)
         elseif headof(x.args[1]) === :local
             seterror!(x, UnsupportedConstLocalVariable)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1324,7 +1324,7 @@ f(arg) = arg
         let
             cst = parse_and_pass("""const x::T = x
             local const x = 1""")
-            @test errorof(cst.args[1]) === StaticLint.TypeDeclOnGlobalVariable
+            @test errorof(cst.args[1]) === (VERSION < v"1.8.0-DEV.1500" ? StaticLint.TypeDeclOnGlobalVariable : nothing)
             @test errorof(cst.args[2]) === StaticLint.UnsupportedConstLocalVariable
         end
     end


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/pull/43671
