### PR TITLE
Fix field mismatch in setup_server

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,8 +1,9 @@
 function setup_server(env = dirname(SymbolServer.Pkg.Types.Context().env.project_file), depot = first(SymbolServer.Pkg.depots()), cache = joinpath(dirname(pathof(SymbolServer)), "..", "store"))
     server = StaticLint.FileServer()
     ssi = SymbolServerInstance(depot, cache)
-    _, server.symbolserver = SymbolServer.getstore(ssi, env)
-    server.symbol_extends  = SymbolServer.collect_extended_methods(server.symbolserver)
+    _, symbols = SymbolServer.getstore(ssi, env)
+    extended_methods = SymbolServer.collect_extended_methods(symbols)
+    server.external_env = ExternalEnv(symbols, extended_methods, Symbol[])
     server
 end
 


### PR DESCRIPTION
17cca44b changed the fields of the FileServer struct without also changing the setup_server method. This fixes that and renames some variables to match the fields.

Fixes #358.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
