### PR TITLE
Fix `ERROR: type DataTypeStore has no field val`

### DIFF
--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -109,7 +109,7 @@ end
 
 function infer_destructuring_type(binding, rb::SymbolServer.DataTypeStore)
     assigned_name = CSTParser.get_name(binding.val)
-    for (fieldname, fieldtype) in zip(rb.val.fieldnames, rb.val.types)
+    for (fieldname, fieldtype) in zip(rb.fieldnames, rb.types)
         if fieldname == assigned_name
             settype!(binding, fieldtype)
             return


### PR DESCRIPTION
It appears to me that the current definition of `DataTypeStore` does not have a `val` field, and instead this code was a typo.

Currently, the language server in VSCode is failing for me with the following backtrace:
```
ERROR: type DataTypeStore has no field val
Stacktrace:
  [1] getproperty(x::Any, f::Symbol)
    @ Base ./Base.jl:37 [inlined]
  [2] infer_destructuring_type(binding::StaticLint.Binding, rb::SymbolServer.DataTypeStore)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/type_inf.jl:112
  [3] infer_type_assignment_rhs(binding::StaticLint.Binding, state::StaticLint.Toplevel{…}, scope::StaticLint.Scope)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/type_inf.jl:62
  [4] infer_type(binding::StaticLint.Binding, scope::StaticLint.Scope, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/type_inf.jl:24
  [5] add_binding(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document}, scope::StaticLint.Scope)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/bindings.jl:361
  [6] add_binding(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/bindings.jl:271 [inlined]
  [7] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:75
  [8] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
  [9] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [10] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
 [11] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [12] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:208
 [13] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [14] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
 [15] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [16] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
 [17] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [18] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
 [19] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [20] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
 [21] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [22] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
 [23] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [24] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
 [25] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [26] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
 [27] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [28] followinclude(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:315
 [29] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:80
 [30] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
 [31] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [32] traverse(x::CSTParser.EXPR, state::StaticLint.Toplevel{LanguageServer.Document})
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:227
 [33] (::StaticLint.Toplevel{LanguageServer.Document})(x::CSTParser.EXPR)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:94
 [34] semantic_pass(file::LanguageServer.Document, modified_expr::Nothing)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:176
 [35] semantic_pass(file::LanguageServer.Document)
    @ StaticLint ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/StaticLint/src/StaticLint.jl:172 [inlined]
 [36] relintserver(server::LanguageServerInstance)
    @ LanguageServer ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/LanguageServer/src/languageserverinstance.jl:439
 [37] run(server::LanguageServerInstance; timings::Vector{Any})
    @ LanguageServer ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/LanguageServer/src/languageserverinstance.jl:419
 [38] run(server::LanguageServerInstance)
    @ LanguageServer ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/packages/LanguageServer/src/languageserverinstance.jl:275
 [39] top-level scope
    @ ~/.vscode/extensions/julialang.language-julia-1.52.2/scripts/languageserver/main.jl:104
 [40] include(mod::Module, _path::String)
    @ Base ./Base.jl:489
 [41] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:318
 [42] _start()
    @ Base ./client.jl:552
```