### PR TITLE
Fix #382. Remove spurious method call error in function definition.

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -330,8 +330,13 @@ function sig_match_any(func::EXPR, x, call_counts, tls::Scope, env::ExternalEnv)
     else
         return true # We shouldn't get here
     end
-    if compare_f_call(m_counts, call_counts) || (CSTParser.rem_where_decl(CSTParser.get_sig(func)) == x)
+    if compare_f_call(m_counts, call_counts)
         return true
+    else
+        x1 = CSTParser.rem_where_decl(CSTParser.get_sig(func))
+        if (x1.head == :call && x1 == x) || (!(x1.args isa Nothing) && x1.args[1].head == :call && x1.args[1] == x)
+            return true
+        end
     end
     return false
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1427,6 +1427,14 @@ f(arg) = arg
         @test errorof(cst.args[3].args[2].args[1].args[3].args[1].args[1]) !== StaticLint.InvalidRedefofConst
     end
 
+    @testset "issue #382" begin
+        cst = parse_and_pass("""
+        function f(a::T, invert=false)::T where {T <: Integer}
+            invert ? -a : a
+        end""")
+        @test !StaticLint.haserror(cst.args[1].args[1].args[1].args[1])
+    end
+
     if VERSION > v"1.5-"
         @testset "issue #210" begin
             cst = parse_and_pass("""h()::@NamedTuple{a::Int,b::String} = (a=1, b = "s")""")


### PR DESCRIPTION
Fixes #382 with a single small change in `src/linting/checks.jl`. In `test/runtest.jl`, I've added the following new test which only passes with the new code:
```
cst = parse_and_pass("""
function f(a::T, invert=false)::T where {T <: Integer}
    invert ? -a : a
end""")
@test !StaticLint.haserror(cst.args[1].args[1].args[1].args[1])
```
