### PR TITLE
fix: early return in add_binding if `name === nothing`

### DIFF
--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -284,6 +284,11 @@ function add_binding(x, state, scope=state.scope)
         else
             return
         end
+
+        # it's not clear how this can happen, but we can just conservatively
+        # return early
+        name === nothing && return
+
         # check for global marker
         if isglobal(name, scope)
             scope = _get_global_scope(state.scope)


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/StaticLint.jl/issues/391.