### PR TITLE
fix: correctly handle parametrized aliases for method definitions

### DIFF
--- a/src/type_inf.jl
+++ b/src/type_inf.jl
@@ -71,6 +71,19 @@ function infer_type_assignment_rhs(binding, state, scope)
                     end
                 end
             end
+        elseif CSTParser.iscurly(rhs)
+            # `const Alias = SomeType{...}` aliases a parameterized type. The
+            # alias is itself a DataType, so adding methods to it is valid.
+            callname = CSTParser.get_name(rhs)
+            if isidentifier(callname)
+                resolve_ref(callname, scope, state)
+                if hasref(callname)
+                    rb = get_root_method(refof(callname), state.server)
+                    if (rb isa Binding && (CoreTypes.isdatatype(rb.type) || rb.val isa SymbolServer.DataTypeStore)) || rb isa SymbolServer.DataTypeStore
+                        settype!(binding, CoreTypes.DataType)
+                    end
+                end
+            end
         elseif headof(rhs) === :INTEGER
             settype!(binding, CoreTypes.Int)
         elseif headof(rhs) === :HEXINT

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2934,3 +2934,35 @@ end
             end
         end"""))
 end
+
+@testitem "constructors on parameterized type aliases (#394)" setup = [SLSetup] begin
+    has_error(cst, err) = any(errorof(x) === err for (_, x) in StaticLint.collect_hints(cst, getenv(server.files[""], server)))
+
+    let cst = parse_and_pass(
+            """
+            module M
+            struct Container{T}
+                value::T
+            end
+            const IntContainer = Container{Int}
+            function IntContainer(x::Float64)
+                return IntContainer(round(Int, x))
+            end
+            end
+            """
+        )
+        @test !has_error(cst, StaticLint.CannotDefineFuncAlreadyHasValue)
+    end
+    let cst = parse_and_pass(
+            """
+            module M
+            struct Foo{A,B} end
+            const Bar = Foo{Int}
+            const Baz = Bar{Int}
+            Baz() = 1
+            end
+            """
+        )
+        @test !has_error(cst, StaticLint.CannotDefineFuncAlreadyHasValue)
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/StaticLint.jl/issues/394.