### PR TITLE
fix: tolerate arg mismatch for macro wrapped functions

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -145,7 +145,7 @@ function _typeof(x, state)
 end
 
 # Call
-function struct_nargs(x::EXPR)
+function struct_nargs(x::EXPR, env::ExternalEnv)
     # struct defs wrapped in macros are likely to have some arbirtary additional constructors, so lets allow anything
     parentof(x) isa EXPR && CSTParser.ismacrocall(parentof(x)) && return 0, typemax(Int), Symbol[], true
     minargs, maxargs, kws, kwsplat = 0, 0, Symbol[], false
@@ -153,14 +153,34 @@ function struct_nargs(x::EXPR)
     length(args.args) == 0 && return 0, typemax(Int), kws, kwsplat
     inner_constructor = findfirst(a -> CSTParser.defines_function(a), args.args)
     if inner_constructor !== nothing
-        return func_nargs(args.args[inner_constructor])
+        return func_nargs(args.args[inner_constructor], env)
     else
         minargs = maxargs = length(args.args)
     end
     return minargs, maxargs, kws, kwsplat
 end
 
-function func_nargs(x::EXPR)
+
+const SIGNATURE_PRESERVING_MACROS = Symbol[
+    Symbol("@inline"),
+    Symbol("@noinline"),
+    Symbol("@propagate_inbounds"),
+    Symbol("@generated"),
+    Symbol("@assume_effects"),
+    Symbol("@constprop"),
+    Symbol("@pure"),
+    Symbol("@nospecializeinfer"),
+]
+
+function func_nargs(x::EXPR, env::ExternalEnv)
+    # early return for macro-wrapped functions, unless we know that the macro
+    # does not modify the signature
+    if parentof(x) isa EXPR && CSTParser.ismacrocall(parentof(x))
+        macroname = parentof(x).args[1]
+        any(n -> _points_to_Base_macro(macroname, n, env), SIGNATURE_PRESERVING_MACROS) ||
+            return 0, typemax(Int), Symbol[], true
+    end
+
     minargs, maxargs, kws, kwsplat = 0, 0, Symbol[], false
     sig = CSTParser.rem_wheres_decls(CSTParser.get_sig(x))
 
@@ -328,9 +348,9 @@ end
 
 function sig_match_any(func::EXPR, x, call_counts, tls::Scope, env::ExternalEnv)
     if CSTParser.defines_function(func)
-        m_counts = func_nargs(func)
+        m_counts = func_nargs(func, env)
     elseif CSTParser.defines_struct(func)
-        m_counts = struct_nargs(func)
+        m_counts = struct_nargs(func, env)
     else
         return true # We shouldn't get here
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -782,7 +782,7 @@ end
             end
             """
         )
-        m_counts = StaticLint.func_nargs(cst.args[1])
+        m_counts = StaticLint.func_nargs(cst.args[1], server.external_env)
         call_counts = StaticLint.call_nargs(cst.args[1].args[2].args[1])
         @test StaticLint.errorof(cst.args[1].args[2].args[1]) === nothing
     end
@@ -792,7 +792,7 @@ end
             func(1, 2)
             """
         )
-        @test StaticLint.func_nargs(cst.args[1]) == (0, typemax(Int), String[], false)
+        @test StaticLint.func_nargs(cst.args[1], server.external_env) == (0, typemax(Int), String[], false)
         @test StaticLint.errorof(cst.args[2]) === nothing
     end
     let cst = parse_and_pass(
@@ -801,7 +801,7 @@ end
             tail(x::Tuple) = argtail(x...)
             """
         )
-        @test StaticLint.func_nargs(cst[1]) == (1, typemax(Int), String[], false)
+        @test StaticLint.func_nargs(cst[1], server.external_env) == (1, typemax(Int), String[], false)
         @test StaticLint.errorof(cst[2]) === nothing
     end
     let cst = parse_and_pass(
@@ -811,7 +811,7 @@ end
             """
         )
 
-        @test StaticLint.func_nargs(cst[1]) == (0, typemax(Int), String[], false)
+        @test StaticLint.func_nargs(cst[1], server.external_env) == (0, typemax(Int), String[], false)
         @test StaticLint.errorof(cst[2]) === nothing
     end
     let cst = parse_and_pass(
@@ -1808,9 +1808,9 @@ end
 end
 
 @testitem "issue #390 (nospecialize without argument)" setup = [SLSetup] begin
-    @test StaticLint.func_nargs(CSTParser.parse("function f(@nospecialize) end")) == (1, 1, Symbol[], false)
-    @test StaticLint.func_nargs(CSTParser.parse("function f(@nospecialize()) end")) == (1, 1, Symbol[], false)
-    @test StaticLint.func_nargs(CSTParser.parse("f(@nospecialize) = 1")) == (1, 1, Symbol[], false)
+    @test StaticLint.func_nargs(CSTParser.parse("function f(@nospecialize) end"), server.external_env) == (1, 1, Symbol[], false)
+    @test StaticLint.func_nargs(CSTParser.parse("function f(@nospecialize()) end"), server.external_env) == (1, 1, Symbol[], false)
+    @test StaticLint.func_nargs(CSTParser.parse("f(@nospecialize) = 1"), server.external_env) == (1, 1, Symbol[], false)
     # Full pipeline: defining and calling such a function must not crash.
     @test parse_and_pass("""
         function f(@nospecialize(x))
@@ -1819,6 +1819,51 @@ end
         end
         f(1)
         """) isa CSTParser.EXPR
+end
+
+@testitem "issue #389 (macro-rewritten call signature)" setup = [SLSetup] begin
+    # An unknown macro wrapping a function definition can rewrite its call
+    # signature (e.g. KernelAbstractions' `@kernel`), so calls with a differing
+    # number of arguments must not be flagged as `IncorrectCallArgs`.
+    let cst = parse_and_pass(
+            """
+            @kernel function mul2_kernel(A)
+                A[I] = 2 * A[I]
+            end
+            mul2_kernel(dev, 64)
+            """
+        )
+        @test errorof(cst.args[2]) === nothing
+        @test StaticLint.func_nargs(cst.args[1].args[end], server.external_env) ==
+            (0, typemax(Int), Symbol[], true)
+    end
+
+    # Signature-preserving Base macros (`@inline`, `Base.@propagate_inbounds`, ...)
+    # resolve to known Base macros, so argument counts are still checked.
+    let cst = parse_and_pass(
+            """
+            @inline function g(x)
+                x
+            end
+            g(1, 2)
+            """
+        )
+        @test errorof(cst.args[2]) === StaticLint.IncorrectCallArgs
+        @test StaticLint.func_nargs(cst.args[1].args[end], server.external_env) ==
+            (1, 1, Symbol[], false)
+    end
+
+    # The module-qualified form (`Base.@propagate_inbounds`) resolves too.
+    let cst = parse_and_pass(
+            """
+            Base.@propagate_inbounds function h(a, b)
+                a + b
+            end
+            h(1)
+            """
+        )
+        @test errorof(cst.args[2]) === StaticLint.IncorrectCallArgs
+    end
 end
 
 @testitem "issue #226" setup = [SLSetup] begin


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/StaticLint.jl/issues/389.