### PR TITLE
fix: stop showing const decl warning for imported bindings

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -825,6 +825,10 @@ end
 # Should return true/false indicating whether the binding should actually be added?
 function check_const_decl(name::String, b::Binding, scope)
     # assumes `scopehasbinding(scope, name)`
+
+    # imported/using-ed bindings are never const decls
+    is_in_fexpr(b.name, x -> headof(x) === :import || headof(x) === :using) && return
+
     b.val isa Binding && return check_const_decl(name, b.val, scope)
     if b.val isa EXPR && (CSTParser.defines_datatype(b.val) || is_const(bind))
         seterror!(b.val, CannotDeclareConst)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1160,6 +1160,59 @@ end
     end
 end
 
+@testitem "importing a type is not a const redefinition (#352)" setup = [SLSetup] begin
+    has_error(cst, err) = any(errorof(x) === err for (_, x) in StaticLint.collect_hints(cst, getenv(server.files[""], server)))
+
+    let cst = parse_and_pass("import Base: AbstractDict")
+        @test !has_error(cst, StaticLint.InvalidRedefofConst)
+    end
+
+    let cst = parse_and_pass(
+            """
+            import Base: AbstractDict
+            import Base: AbstractDict
+            """
+        )
+        @test !has_error(cst, StaticLint.InvalidRedefofConst)
+    end
+
+    let cst = parse_and_pass(
+            """
+            using Base
+            using Base: AbstractDict
+            """
+        )
+        @test !has_error(cst, StaticLint.InvalidRedefofConst)
+    end
+
+    let cst = parse_and_pass(
+            """
+            import Base
+            import Base: AbstractDict
+            """
+        )
+        @test !has_error(cst, StaticLint.InvalidRedefofConst)
+    end
+
+    let cst = parse_and_pass(
+            """
+            using Base
+            import Base: AbstractDict
+            """
+        )
+        @test !has_error(cst, StaticLint.InvalidRedefofConst)
+    end
+
+    let cst = parse_and_pass(
+            """
+            import Base: AbstractDict
+            const AbstractDict = 1
+            """
+        )
+        @test has_error(cst, StaticLint.InvalidRedefofConst)
+    end
+end
+
 @testitem "@testitem/@testset blocks have isolated scopes (#405)" setup = [SLSetup] begin
     has_error(cst, err) = any(errorof(x) === err for (_, x) in StaticLint.collect_hints(cst, getenv(server.files[""], server)))
 


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/StaticLint.jl/issues/352.